### PR TITLE
Fixed prop in skeleton dungeons not being used closes #18 (forge/1.16)

### DIFF
--- a/src/main/resources/data/betterdungeons/worldgen/template_pool/skeleton_dungeon/2x3.json
+++ b/src/main/resources/data/betterdungeons/worldgen/template_pool/skeleton_dungeon/2x3.json
@@ -32,7 +32,7 @@
     {
       "weight": 1,
       "element": {
-        "location": "2x3_3",
+        "location": "betterdungeons:skeleton_dungeon/2x3/2x3_3",
         "processors": "betterdungeons:skeleton_dungeon/skeleton_dungeon",
         "projection": "rigid",
         "element_type": "minecraft:single_pool_element"


### PR DESCRIPTION
Fixed prop in skeleton dungeons not being used closes #18 (forge/1.16)

Signed-off-by: apple <davidalb97@hotmail.com>