### PR TITLE
Add advancement keys and update available lang files

### DIFF
--- a/Common/src/main/resources/assets/betterdungeons/lang/en_us.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/en_us.json
@@ -13,37 +13,25 @@
   "Banner of Rage": "Banner of Rage",
 
   "betterdungeons.advancements.root.title": "YUNG's Better Dungeons",
-  "YUNG's Better Dungeons": "YUNG's Better Dungeons",
   "betterdungeons.advancements.root.description": "Adventure awaits...",
-  "Adventure awaits...": "Adventure awaits...",
 
   "betterdungeons.advancements.all_dungeons.title": "Professional Dungeoneer",
-  "Professional Dungeoneer": "Professional Dungeoneer",
   "betterdungeons.advancements.all_dungeons.description": "Explore all of the Better Dungeons!",
-  "Explore all of the Better Dungeons!": "Explore all of the Better Dungeons!",
 
   "betterdungeons.advancements.small_dungeon.title": "Quite the Renovation",
-  "Quite the Renovation": "Quite the Renovation",
   "betterdungeons.advancements.small_dungeon.description": "Find an upgraded Monster Room",
-  "Find an upgraded Monster Room": "Find an upgraded Monster Room",
 
   "betterdungeons.advancements.skeleton_dungeon.title": "A Bone to Pick",
-  "A Bone to Pick": "A Bone to Pick",
   "betterdungeons.advancements.skeleton_dungeon.description": "Enter a Fortress of the Undead",
-  "Enter a Fortress of the Undead": "Enter a Fortress of the Undead",
 
   "betterdungeons.advancements.spider_dungeon.title": "Cobweb Entanglement",
-  "Cobweb Entanglement": "Cobweb Entanglement",
   "betterdungeons.advancements.spider_dungeon.description": "Discover a Spider Cave",
-  "Discover a Spider Cave": "Discover a Spider Cave",
 
   "betterdungeons.advancements.zombie_dungeon.title": "When in Rome",
-  "When in Rome": "When in Rome",
   "betterdungeons.advancements.zombie_dungeon.description": "Set foot in a Catacomb",
-  "Set foot in a Catacomb": "Set foot in a Catacomb",
 
-  "A Special Addition": "A Special Addition",
-  "Find a Small Nether Dungeon": "Find a Small Nether Dungeon",
+  "betterdungeons.advancements.small_nether_dungeon.title": "A Special Addition",
+  "betterdungeons.advancements.small_nether_dungeon.description": "Find a Small Nether Dungeon",
 
   "text.autoconfig.betterdungeons-fabric-1_21.title": "YUNG's Better Dungeons",
 

--- a/Common/src/main/resources/assets/betterdungeons/lang/es_es.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/es_es.json
@@ -13,37 +13,25 @@
   "Banner of Rage": "Estandarte de ira",
 
   "betterdungeons.advancements.root.title": "YUNG's Better Dungeons",
-  "YUNG's Better Dungeons": "YUNG's Better Dungeons",
   "betterdungeons.advancements.root.description": "La aventura espera...",
-  "Adventure awaits...": "La aventura espera...",
 
   "betterdungeons.advancements.all_dungeons.title": "Mazmorreador profesional",
-  "Professional Dungeoneer": "Mazmorreador profesional",
   "betterdungeons.advancements.all_dungeons.description": "¡Explora todo lo de Better Dungeons!",
-  "Explore all of the Better Dungeons!": "¡Explora todo lo de Better Dungeons!",
 
   "betterdungeons.advancements.small_dungeon.title": "Toda la renovación",
-  "Quite the Renovation": "Toda la renovación",
   "betterdungeons.advancements.small_dungeon.description": "Encuentra una sala de monstruos mejorada",
-  "Find an upgraded Monster Room": "Encuentra una sala de monstruos mejorada",
 
   "betterdungeons.advancements.skeleton_dungeon.title": "Un hueso que escoger",
-  "A Bone to Pick": "Un hueso que escoger",
   "betterdungeons.advancements.skeleton_dungeon.description": "Entra en una fortaleza de los no muertos",
-  "Enter a Fortress of the Undead": "Entra en una fortaleza de los no muertos",
 
   "betterdungeons.advancements.spider_dungeon.title": "Enredo de telarañas",
-  "Cobweb Entanglement": "Enredo de telarañas",
   "betterdungeons.advancements.spider_dungeon.description": "Descubre una cueva de arañas",
-  "Discover a Spider Cave": "Descubre una cueva de arañas",
 
   "betterdungeons.advancements.zombie_dungeon.title": "Cuando en Roma",
-  "When in Rome": "Cuando en Roma",
   "betterdungeons.advancements.zombie_dungeon.description": "Pon un pie en una catacumba",
-  "Set foot in a Catacomb": "Pon un pie en una catacumba",
 
-  "A Special Addition": "Una adición especial",
-  "Find a Small Nether Dungeon": "Encuentra una mazmorra del Nether pequeña",
+  "betterdungeons.advancements.small_nether_dungeon.title": "Una adición especial",
+  "betterdungeons.advancements.small_nether_dungeon.description": "Encuentra una mazmorra del Nether pequeña",
 
   "text.autoconfig.betterdungeons-fabric-1_21.title": "YUNG's Better Dungeons",
 

--- a/Common/src/main/resources/assets/betterdungeons/lang/it_it.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/it_it.json
@@ -1,4 +1,6 @@
 {
+  "Small Nether Dungeons are currently disabled by default. You can enable them in the mod's config.": "Piccoli Dungeon Nether sono attualmente disabilitati per impostazione predefinita. Puoi abilitarli nella configurazione della mod.",
+
   "betterdungeons.small_dungeon.banner.zombie": "Stendardo disgustoso",
   "Foul Banner": "Stendardo disgustoso",
   "betterdungeons.small_dungeon.banner.skeleton": "Stendardo vendicativo",
@@ -6,33 +8,41 @@
   "betterdungeons.small_dungeon.banner.spider": "Stendardo infestato",
   "Haunted Banner": "Stendardo infestato",
 
+  "Banner of Decay": "Stendardo di decadimento",
+  "Banner of Pork": "Stendardo di maiale",
+  "Banner of Rage": "Stendardo della rabbia",
+
   "betterdungeons.advancements.root.title": "YUNG's Better Dungeons",
-  "YUNG's Better Dungeons": "YUNG's Better Dungeons",
   "betterdungeons.advancements.root.description": "Un'avventura ti aspetta...",
-  "Adventure awaits...": "Un'avventura ti aspetta...",
 
   "betterdungeons.advancements.all_dungeons.title": "Dungeoneer professionista",
-  "Professional Dungeoneer": "Dungeoneer professionista",
   "betterdungeons.advancements.all_dungeons.description": "Esplora tutto il Better Dungeons!",
-  "Explore all of the Better Dungeons!": "Esplora tutto il Better Dungeons!",
 
   "betterdungeons.advancements.small_dungeon.title": "Che bella ristrutturazione",
-  "Quite the Renovation": "Che bella ristrutturazione",
   "betterdungeons.advancements.small_dungeon.description": "Trova una stanza dei mostri migliorata",
-  "Find an upgraded Monster Room": "Trova una stanza dei mostri migliorata",
 
   "betterdungeons.advancements.skeleton_dungeon.title": "Una questione in sospeso",
-  "A Bone to Pick": "Una questione in sospeso",
   "betterdungeons.advancements.skeleton_dungeon.description": "Entra in una fortezza dei non-morti",
-  "Enter a Fortress of the Undead": "Entra in una fortezza dei non-morti",
 
   "betterdungeons.advancements.spider_dungeon.title": "Groviglio di ragnatele",
-  "Cobweb Entanglement": "Groviglio di ragnatele",
   "betterdungeons.advancements.spider_dungeon.description": "Scopri una caverna di ragni",
-  "Discover a Spider Cave": "Scopri una caverna di ragni",
 
   "betterdungeons.advancements.zombie_dungeon.title": "Quando a roma",
-  "When in Rome": "Quando a roma",
   "betterdungeons.advancements.zombie_dungeon.description": "Entra in una catacomba",
-  "Set foot in a Catacomb": "Entra in una catacomba"
+
+  "betterdungeons.advancements.small_nether_dungeon.title": "Un'aggiunta speciale",
+  "betterdungeons.advancements.small_nether_dungeon.description": "Trova un piccolo dungeon Nether",
+
+  "text.autoconfig.betterdungeons-fabric-1_21.title": "YUNG's Better Dungeons",
+
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons": "YUNG's Better Dungeons",
+
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general": "Impostazioni generali",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.@Tooltip": "Impostazioni generali",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.zombieDungeon": "Dungeon Zombie",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.zombieDungeon.@Tooltip": "Dungeon Zombie",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallDungeon": "Piccoli dungeon",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallDungeon.@Tooltip": "Piccoli dungeon",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallNetherDungeon": "Piccoli dungeon Nether",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallNetherDungeon.@Tooltip": "Piccoli dungeon Nether"
 }

--- a/Common/src/main/resources/assets/betterdungeons/lang/pt_br.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/pt_br.json
@@ -1,5 +1,5 @@
 {
-  "Small Nether Dungeons are currently disabled by default. You can enable them in the mod's config.": "Pequenos Calabouços do Nether estão desativados por padrão. Você pode ativá-los nas configurações do mod.",
+  "Pequenas Masmorras Do Nether are currently disabled by default. You can enable them in the mod's config.": "Pequenos Calabouços do Nether estão desativados por padrão. Você pode ativá-los nas configurações do mod.",
 
   "betterdungeons.small_dungeon.banner.zombie": "Estandarte Fétido",
   "Foul Banner": "Estandarte Fétido",
@@ -13,39 +13,36 @@
   "Banner of Rage": "Estandarte da Fúria",
 
   "betterdungeons.advancements.root.title": "YUNG's Melhores Calabouços",
-  "YUNG's Better Dungeons": "YUNG's Melhores Calabouços",
   "betterdungeons.advancements.root.description": "A aventura te espera...",
-  "Adventure awaits...": "A aventura te espera...",
 
   "betterdungeons.advancements.all_dungeons.title": "Explorador de Calabouços Profissional",
-  "Professional Dungeoneer": "Explorador de Calabouços Profissional",
   "betterdungeons.advancements.all_dungeons.description": "Explore todos os Melhores Calabouços!",
-  "Explore all of the Better Dungeons!": "Explore todos os Melhores Calabouços!",
 
   "betterdungeons.advancements.small_dungeon.title": "Grande Reforma",
-  "Quite the Renovation": "Grande Reforma",
   "betterdungeons.advancements.small_dungeon.description": "Encontre uma Sala de Monstros melhorada",
-  "Find an upgraded Monster Room": "Encontre uma Sala de Monstros melhorada",
 
   "betterdungeons.advancements.skeleton_dungeon.title": "Pendência Óssea",
-  "A Bone to Pick": "Pendência Óssea",
   "betterdungeons.advancements.skeleton_dungeon.description": "Entre em uma Fortaleza dos Mortos-Vivos",
-  "Enter a Fortress of the Undead": "Entre em uma Fortaleza dos Mortos-Vivos",
 
   "betterdungeons.advancements.spider_dungeon.title": "Enredado em Teias",
-  "Cobweb Entanglement": "Enredado em Teias",
   "betterdungeons.advancements.spider_dungeon.description": "Descubra uma Caverna de Aranhas",
-  "Discover a Spider Cave": "Descubra uma Caverna de Aranhas",
 
   "betterdungeons.advancements.zombie_dungeon.title": "Quando em Roma",
-  "When in Rome": "Quando em Roma",
   "betterdungeons.advancements.zombie_dungeon.description": "Ponha os pés em uma Catacumba",
-  "Set foot in a Catacomb": "Ponha os pés em uma Catacumba",
 
-  "A Special Addition": "Uma Adição Especial",
-  "Find a Small Nether Dungeon": "Encontre um Pequeno Calabouço do Nether",
+  "betterdungeons.advancements.small_nether_dungeon.title": "Uma Adição Especial",
+  "betterdungeons.advancements.small_nether_dungeon.description": "Encontre um Pequeno Calabouço do Nether",
 
   "text.autoconfig.betterdungeons-fabric-1_21.title": "YUNG's Melhores Calabouços",
 
-  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons": "YUNG's Melhores Calabouços"
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons": "YUNG's Melhores Calabouços",
+
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general": "Configurações Gerais",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.@Tooltip": "Configurações Gerais",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.zombieDungeon": "Calabouços de Zumbis",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.zombieDungeon.@Tooltip": "Calabouços de Zumbis",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallDungeon": "Calabouços Pequenas",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallDungeon.@Tooltip": "Calabouços Pequenas",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallNetherDungeon": "Pequenos Calabouços do Nether",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallNetherDungeon.@Tooltip": "Pequenos Calabouços do Nether"
 }

--- a/Common/src/main/resources/assets/betterdungeons/lang/ru_ru.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/ru_ru.json
@@ -8,42 +8,30 @@
   "betterdungeons.small_dungeon.banner.spider": "Призрачное знамя",
   "Haunted Banner": "Призрачное знамя",
 
-  "Banner of Decay": "Знамяраспада",
+  "Banner of Decay": "Знамя распада",
   "Banner of Pork": "Свинознамя",
   "Banner of Rage": "Знамя ярости",
 
   "betterdungeons.advancements.root.title": "Улучшенные сокровищницы YUNG'а",
-  "YUNG's Better Dungeons": "Улучшенные сокровищницы YUNG'а",
-  "betterdungeons.advancements.root.description": "Приключение ждёт…",
-  "Adventure awaits...": "Приключение ждёт…",
+  "betterdungeons.advancements.root.description": "Приключение ждёт...",
 
-  "betterdungeons.advancements.all_dungeons.title": "Профессиональный подземельщик",
-  "Professional Dungeoneer": "Профессиональный подземельщик",
+  "betterdungeons.advancements.all_dungeons.title": "Хозяин подземелий",
   "betterdungeons.advancements.all_dungeons.description": "Исследуйте все улучшенные сокровищницы!",
-  "Explore all of the Better Dungeons!": "Исследуйте все улучшенные сокровищницы!",
 
-  "betterdungeons.advancements.small_dungeon.title": "Неплохой ремонт",
-  "Quite the Renovation": "Неплохой ремонт",
+  "betterdungeons.advancements.small_dungeon.title": "Евроремонт",
   "betterdungeons.advancements.small_dungeon.description": "Найдите улучшенную малую сокровищницу монстров",
-  "Find an upgraded Monster Room": "Найдите улучшенную малую сокровищницу монстров",
 
-  "betterdungeons.advancements.skeleton_dungeon.title": "Кость, которую нужно обглодать",
-  "A Bone to Pick": "Кость, которую нужно обглодать",
+  "betterdungeons.advancements.skeleton_dungeon.title": "Кость брошена",
   "betterdungeons.advancements.skeleton_dungeon.description": "Войдите в крепость нежити",
-  "Enter a Fortress of the Undead": "Войдите в крепость нежити",
 
   "betterdungeons.advancements.spider_dungeon.title": "Запутанность в паутине",
-  "Cobweb Entanglement": "Запутанность в паутине",
   "betterdungeons.advancements.spider_dungeon.description": "Откройте для себя паучью пещеру",
-  "Discover a Spider Cave": "Откройте для себя паучью пещеру",
 
   "betterdungeons.advancements.zombie_dungeon.title": "Когда был в Риме",
-  "When in Rome": "Когда был в Риме",
   "betterdungeons.advancements.zombie_dungeon.description": "Ступите в катакомбы",
-  "Set foot in a Catacomb": "Ступите в катакомбы",
 
-  "A Special Addition": "Специальное дополнение",
-  "Find a Small Nether Dungeon": "Найдите незерскую сокровищницы",
+  "betterdungeons.advancements.small_nether_dungeon.title": "Специальное дополнение",
+  "betterdungeons.advancements.small_nether_dungeon.description": "Найдите незерскую сокровищницу",
 
   "text.autoconfig.betterdungeons-fabric-1_21.title": "Улучшенные сокровищницы YUNG'а",
 
@@ -64,7 +52,7 @@
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.enableHeads.@Tooltip[2]": "По умолчанию: true",
 
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.removeVanillaDungeons": "Удалите ванильные сокровищницы",
-  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.removeVanillaDungeons.@Tooltip[0]": "Whether or not vanilla dungeons should be prevented from spawning in the world.",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.removeVanillaDungeons.@Tooltip[0]": "Следует ли предотвратить появление ванильных сокровищниц в мире или нет.",
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.removeVanillaDungeons.@Tooltip[1]": "Рекомендуется отключить их, так как малые сокровищницы очень похожи по дизайну.",
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.removeVanillaDungeons.@Tooltip[2]": "По умолчанию: true",
 

--- a/Common/src/main/resources/assets/betterdungeons/lang/uk_ua.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/uk_ua.json
@@ -1,4 +1,6 @@
 {
+  "Small Nether Dungeons are currently disabled by default. You can enable them in the mod's config.": "Невеликі підземелля Незеру в даний час за замовчуванням відключені. Ви можете включити їх в налаштуваннях мода.",
+
   "betterdungeons.small_dungeon.banner.zombie": "Брудний стяг",
   "Foul Banner": "Брудний стяг",
   "betterdungeons.small_dungeon.banner.skeleton": "Стяг помсти",
@@ -6,39 +8,34 @@
   "betterdungeons.small_dungeon.banner.spider": "Стяг переслідувача",
   "Haunted Banner": "Стяг переслідувача",
 
-  "betterdungeons.advancements.root.title": "YUNG's Кращі підземелля",
-  "YUNG's Better Dungeons": "YUNG's Кращі підземелля",
+  "Banner of Decay": "Стяг розпаду",
+  "Banner of Pork": "Стяг свинини",
+  "Banner of Rage": "Стяг люті",
+
+  "betterdungeons.advancements.root.title": "Кращі підземелля YUNG'а",
   "betterdungeons.advancements.root.description": "Пригоди чекають...",
-  "Adventure awaits...": "Пригоди чекають...",
 
   "betterdungeons.advancements.all_dungeons.title": "Данджен мастєр",
-  "Professional Dungeoneer": "Данджен мастєр",
   "betterdungeons.advancements.all_dungeons.description": "Дослідіть усі кращі підземелля!",
-  "Explore all of the Better Dungeons!": "Дослідіть усі кращі підземелля!",
 
   "betterdungeons.advancements.small_dungeon.title": "Євроремонт",
-  "Quite the Renovation": "Євроремонт",
   "betterdungeons.advancements.small_dungeon.description": "Знайдіть оновлену Кімнату монстрів",
-  "Find an upgraded Monster Room": "Знайдіть оновлену Кімнату монстрів",
 
   "betterdungeons.advancements.skeleton_dungeon.title": "Пограємо в кості?",
-  "A Bone to Pick": "Пограємо в кості?",
   "betterdungeons.advancements.skeleton_dungeon.description": "Увійдіть до Фортеці нежиті",
-  "Enter a Fortress of the Undead": "Увійдіть до Фортеці нежиті",
 
   "betterdungeons.advancements.spider_dungeon.title": "Заплутатись у павутині",
-  "Cobweb Entanglement": "Заплутатись у павутині",
   "betterdungeons.advancements.spider_dungeon.description": "Відвідайте підземелля павуків",
-  "Discover a Spider Cave": "Відвідайте підземелля павуків",
 
   "betterdungeons.advancements.zombie_dungeon.title": "Скільки ще до Риму",
-  "When in Rome": "Скільки ще до Риму",
   "betterdungeons.advancements.zombie_dungeon.description": "Ступіть в катакомби",
-  "Set foot in a Catacomb": "Ступіть в катакомби",
 
-  "text.autoconfig.betterdungeons-fabric-1_21.title": "YUNG's Кращі підземелля",
+  "betterdungeons.advancements.small_nether_dungeon.title": "Особливе доповнення",
+  "betterdungeons.advancements.small_nether_dungeon.description": "Знайдіть мале підземелля Незеру",
 
-  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons": "YUNG's Кращі підземелля",
+  "text.autoconfig.betterdungeons-fabric-1_21.title": "Кращі підземелля YUNG'а",
+
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons": "Кращі підземелля YUNG'а",
 
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general": "Головні налаштування",
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.@Tooltip": "Головні налаштування",
@@ -46,6 +43,8 @@
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.zombieDungeon.@Tooltip": "Підземелля зомбі",
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallDungeon": "Мале підземелля",
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallDungeon.@Tooltip": "Мале підземелля",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallNetherDungeon": "Мале підземелля Незеру",
+  "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.smallNetherDungeon.@Tooltip": "Мале підземелля Незеру",
 
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.enableHeads": "Дозволити черепи та голови",
   "text.autoconfig.betterdungeons-fabric-1_21.option.betterDungeons.general.enableHeads.@Tooltip[0]": "Чи слід дозволяти підземеллям розміщувати черепи скелетів та голови інших мобів.",

--- a/Common/src/main/resources/data/betterdungeons/advancement/all_dungeons.json
+++ b/Common/src/main/resources/data/betterdungeons/advancement/all_dungeons.json
@@ -6,10 +6,12 @@
       "id": "minecraft:diamond_sword"
     },
     "title": {
-      "translate": "Professional Dungeoneer"
+      "translate": "betterdungeons.advancements.all_dungeons.title",
+      "fallback": "Professional Dungeoneer"
     },
     "description": {
-      "translate": "Explore all of the Better Dungeons!"
+      "translate": "betterdungeons.advancements.all_dungeons.description",
+      "fallback": "Explore all of the Better Dungeons!"
     },
     "show_toast": true,
     "announce_to_chat": true,
@@ -82,17 +84,9 @@
     }
   },
   "requirements": [
-    [
-      "in_better_monster_room"
-    ],
-    [
-      "in_better_zombie_dungeon"
-    ],
-    [
-      "in_better_skeleton_dungeon"
-    ],
-    [
-      "in_better_spider_dungeon"
-    ]
+    ["in_better_monster_room"],
+    ["in_better_zombie_dungeon"],
+    ["in_better_skeleton_dungeon"],
+    ["in_better_spider_dungeon"]
   ]
 }

--- a/Common/src/main/resources/data/betterdungeons/advancement/root.json
+++ b/Common/src/main/resources/data/betterdungeons/advancement/root.json
@@ -5,10 +5,12 @@
       "id": "minecraft:mossy_stone_bricks"
     },
     "title": {
-      "translate": "YUNG's Better Dungeons"
+      "translate": "betterdungeons.advancements.root.title",
+      "fallback": "YUNG's Better Dungeons"
     },
     "description": {
-      "translate": "Adventure awaits..."
+      "translate": "betterdungeons.advancements.root.description",
+      "fallback": "Adventure awaits..."
     },
     "show_toast": false,
     "announce_to_chat": false,

--- a/Common/src/main/resources/data/betterdungeons/advancement/skeleton_dungeon.json
+++ b/Common/src/main/resources/data/betterdungeons/advancement/skeleton_dungeon.json
@@ -6,10 +6,12 @@
       "id": "minecraft:skeleton_skull"
     },
     "title": {
-      "translate": "A Bone to Pick"
+      "translate": "betterdungeons.advancements.skeleton_dungeon.title",
+      "fallback": "A Bone to Pick"
     },
     "description": {
-      "translate": "Enter a Fortress of the Undead"
+      "translate": "betterdungeons.advancements.skeleton_dungeon.description",
+      "fallback": "Enter a Fortress of the Undead"
     },
     "show_toast": true,
     "announce_to_chat": true,

--- a/Common/src/main/resources/data/betterdungeons/advancement/small_dungeon.json
+++ b/Common/src/main/resources/data/betterdungeons/advancement/small_dungeon.json
@@ -6,10 +6,12 @@
       "id": "minecraft:spawner"
     },
     "title": {
-      "translate": "Quite the Renovation"
+      "translate": "betterdungeons.advancements.small_dungeon.title",
+      "fallback": "Quite the Renovation"
     },
     "description": {
-      "translate": "Find an upgraded Monster Room"
+      "translate": "betterdungeons.advancements.small_dungeon.description",
+      "fallback": "Find an upgraded Monster Room"
     },
     "show_toast": true,
     "announce_to_chat": true,
@@ -33,9 +35,5 @@
       }
     }
   },
-  "requirements": [
-    [
-      "in_better_monster_room"
-    ]
-  ]
+  "requirements": [["in_better_monster_room"]]
 }

--- a/Common/src/main/resources/data/betterdungeons/advancement/small_nether_dungeon.json
+++ b/Common/src/main/resources/data/betterdungeons/advancement/small_nether_dungeon.json
@@ -6,10 +6,12 @@
       "id": "minecraft:red_nether_bricks"
     },
     "title": {
-      "translate": "A Special Addition"
+      "translate": "betterdungeons.advancements.small_nether_dungeon.title",
+      "fallback": "A Special Addition"
     },
     "description": {
-      "translate": "Find a Small Nether Dungeon"
+      "translate": "betterdungeons.advancements.small_nether_dungeon.description",
+      "fallback": "Find a Small Nether Dungeon"
     },
     "show_toast": true,
     "announce_to_chat": true,

--- a/Common/src/main/resources/data/betterdungeons/advancement/spider_dungeon.json
+++ b/Common/src/main/resources/data/betterdungeons/advancement/spider_dungeon.json
@@ -6,10 +6,12 @@
       "id": "minecraft:string"
     },
     "title": {
-      "translate": "Cobweb Entanglement"
+      "translate": "betterdungeons.advancements.spider_dungeon.title",
+      "fallback": "Cobweb Entanglement"
     },
     "description": {
-      "translate": "Discover a Spider Cave"
+      "translate": "betterdungeons.advancements.spider_dungeon.description",
+      "fallback": "Discover a Spider Cave"
     },
     "show_toast": true,
     "announce_to_chat": true,

--- a/Common/src/main/resources/data/betterdungeons/advancement/zombie_dungeon.json
+++ b/Common/src/main/resources/data/betterdungeons/advancement/zombie_dungeon.json
@@ -6,10 +6,12 @@
       "id": "minecraft:rotten_flesh"
     },
     "title": {
-      "translate": "When in Rome"
+      "translate": "betterdungeons.advancements.zombie_dungeon.title",
+      "fallback": "When in Rome"
     },
     "description": {
-      "translate": "Set foot in a Catacomb"
+      "translate": "betterdungeons.advancements.zombie_dungeon.description",
+      "fallback": "Set foot in a Catacomb"
     },
     "show_toast": true,
     "announce_to_chat": true,


### PR DESCRIPTION
Replaced the current translation keys for titles and descriptions of advancements with technical lines using the `fallback` function.
Removed now unused keys in all available language files. Updated `ru_ru.json`. Added some missing lines using machine translation for `es_es.json`, `it_it.json`, `pt_br.json`, `uk_ua.json`.