### PR TITLE
Fixes localized advancement names for russian

### DIFF
--- a/Common/src/main/resources/assets/betterdungeons/lang/ru_ru.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/ru_ru.json
@@ -30,7 +30,7 @@
   "betterdungeons.advancements.spider_dungeon.title": "Запутанность в паутине",
   "betterdungeons.advancements.spider_dungeon.description": "Откройте для себя паучью пещеру",
 
-  "betterdungeons.advancements.zombie_dungeon.title": "Когда был в Риме",
+  "betterdungeons.advancements.zombie_dungeon.title": "В чужой монастырь",
   "betterdungeons.advancements.zombie_dungeon.description": "Ступите в катакомбы",
 
   "betterdungeons.advancements.small_nether_dungeon.title": "Специальное дополнение",

--- a/Common/src/main/resources/assets/betterdungeons/lang/uk_ua.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/uk_ua.json
@@ -30,7 +30,7 @@
   "betterdungeons.advancements.spider_dungeon.title": "Заплутатись у павутині",
   "betterdungeons.advancements.spider_dungeon.description": "Відвідайте підземелля павуків",
 
-  "betterdungeons.advancements.zombie_dungeon.title": "Скільки ще до Риму",
+  "betterdungeons.advancements.zombie_dungeon.title": "У чужий монастир",
   "betterdungeons.advancements.zombie_dungeon.description": "Ступіть в катакомби",
 
   "betterdungeons.advancements.small_nether_dungeon.title": "Особливе доповнення",

--- a/Common/src/main/resources/assets/betterdungeons/lang/uk_ua.json
+++ b/Common/src/main/resources/assets/betterdungeons/lang/uk_ua.json
@@ -30,7 +30,7 @@
   "betterdungeons.advancements.spider_dungeon.title": "Заплутатись у павутині",
   "betterdungeons.advancements.spider_dungeon.description": "Відвідайте підземелля павуків",
 
-  "betterdungeons.advancements.zombie_dungeon.title": "У чужий монастир",
+  "betterdungeons.advancements.zombie_dungeon.title": "Скільки ще до Риму",
   "betterdungeons.advancements.zombie_dungeon.description": "Ступіть в катакомби",
 
   "betterdungeons.advancements.small_nether_dungeon.title": "Особливе доповнення",


### PR DESCRIPTION
This pr fixes the "When in Rome" achievement translation from "Когда был в Риме" (literal translation "When I was in Rome" ) to "В чужой монастырь" (literal translation "Into a foreign monastery").

In Russian the idiom is "В чужой монастырь со своим уставом не ходят" (You don't go into a foreign monastery with your own charter) instead of "Будучи в Риме, поступай как римляне" (When in rome, do as the romans do) 


reason why merge this: 
Current translation confuses Russian speakers because the idiom "When in Rome" is not used in that language.