### PR TITLE
Update to Minecraft 26.2

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/module/StructureProcessorTypeModule.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/module/StructureProcessorTypeModule.java
@@ -31,99 +31,100 @@ import com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon
 import com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon.ZombieRotProcessor;
 import com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon.ZombieTombstoneSpawnerProcessor;
 import com.yungnickyoung.minecraft.yungsapi.api.autoregister.AutoRegister;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 
 @AutoRegister(BetterDungeonsCommon.MOD_ID)
 public class StructureProcessorTypeModule {
     @AutoRegister("mob_spawner_processor")
-    public static StructureProcessorType<MobSpawnerProcessor> MOB_SPAWNER_PROCESSOR = () -> MobSpawnerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> MOB_SPAWNER_PROCESSOR = MobSpawnerProcessor.CODEC;
 
     @AutoRegister("head_processor")
-    public static StructureProcessorType<HeadProcessor> HEAD_PROCESSOR = () -> HeadProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> HEAD_PROCESSOR = HeadProcessor.CODEC;
 
     @AutoRegister("nether_block_processor")
-    public static StructureProcessorType<NetherBlockProcessor> NETHER_BLOCK_PROCESSOR = () -> NetherBlockProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> NETHER_BLOCK_PROCESSOR = NetherBlockProcessor.CODEC;
 
     @AutoRegister("candle_processor")
-    public static StructureProcessorType<CandleProcessor> CANDLE_PROCESSOR = () -> CandleProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> CANDLE_PROCESSOR = CandleProcessor.CODEC;
 
     /* Small dungeons */
     @AutoRegister("small_dungeon_ceiling_prop_processor")
-    public static StructureProcessorType<SmallDungeonCeilingPropProcessor> SMALL_DUNGEON_CEILING_PROP_PROCESSOR = () -> SmallDungeonCeilingPropProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_CEILING_PROP_PROCESSOR = SmallDungeonCeilingPropProcessor.CODEC;
 
     @AutoRegister("small_dungeon_ceiling_lamp_processor")
-    public static StructureProcessorType<SmallDungeonCeilingLampPropProcessor> SMALL_DUNGEON_CEILING_LAMP_PROCESSOR = () -> SmallDungeonCeilingLampPropProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_CEILING_LAMP_PROCESSOR = SmallDungeonCeilingLampPropProcessor.CODEC;
 
     @AutoRegister("small_dungeon_banner_processor")
-    public static StructureProcessorType<SmallDungeonBannerProcessor> SMALL_DUNGEON_BANNER_PROCESSOR = () -> SmallDungeonBannerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_BANNER_PROCESSOR = SmallDungeonBannerProcessor.CODEC;
 
     @AutoRegister("small_dungeon_chest_processor")
-    public static StructureProcessorType<SmallDungeonChestProcessor> SMALL_DUNGEON_CHEST_PROCESSOR = () -> SmallDungeonChestProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_CHEST_PROCESSOR = SmallDungeonChestProcessor.CODEC;
 
     @AutoRegister("small_dungeon_cobblestone_processor")
-    public static StructureProcessorType<SmallDungeonCobblestoneProcessor> SMALL_DUNGEON_COBBLE_PROCESSOR = () -> SmallDungeonCobblestoneProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_COBBLE_PROCESSOR = SmallDungeonCobblestoneProcessor.CODEC;
 
     @AutoRegister("small_dungeon_leg_processor")
-    public static StructureProcessorType<SmallDungeonLegProcessor> SMALL_DUNGEON_LEG_PROCESSOR = () -> SmallDungeonLegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_LEG_PROCESSOR = SmallDungeonLegProcessor.CODEC;
 
     @AutoRegister("small_dungeon_ceiling_processor")
-    public static StructureProcessorType<SmallDungeonCeilingProcessor> SMALL_DUNGEON_CEILING_PROCESSOR = () -> SmallDungeonCeilingProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_CEILING_PROCESSOR = SmallDungeonCeilingProcessor.CODEC;
 
     @AutoRegister("small_dungeon_ore_processor")
-    public static StructureProcessorType<SmallDungeonOreProcessor> SMALL_DUNGEON_ORE_PROCESSOR = () -> SmallDungeonOreProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_ORE_PROCESSOR = SmallDungeonOreProcessor.CODEC;
 
     /* Small Nether Dungeons */
     @AutoRegister("small_nether_dungeon_banner_processor")
-    public static StructureProcessorType<SmallNetherDungeonBannerProcessor> SMALL_NETHER_DUNGEON_BANNER_PROCESSOR = () -> SmallNetherDungeonBannerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_BANNER_PROCESSOR = SmallNetherDungeonBannerProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_head_processor")
-    public static StructureProcessorType<SmallNetherDungeonHeadProcessor> SMALL_NETHER_DUNGEON_HEAD_PROCESSOR = () -> SmallNetherDungeonHeadProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_HEAD_PROCESSOR = SmallNetherDungeonHeadProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_lava_block_processor")
-    public static StructureProcessorType<SmallNetherDungeonLavaBlockProcessor> SMALL_NETHER_DUNGEON_LAVA_BLOCK_PROCESSOR = () -> SmallNetherDungeonLavaBlockProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_LAVA_BLOCK_PROCESSOR = SmallNetherDungeonLavaBlockProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_entrance_stairs_processor")
-    public static StructureProcessorType<SmallNetherDungeonEntranceStairsProcessor> SMALL_NETHER_DUNGEON_ENTRANCE_STAIRS_PROCESSOR = () -> SmallNetherDungeonEntranceStairsProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_ENTRANCE_STAIRS_PROCESSOR = SmallNetherDungeonEntranceStairsProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_leg_processor")
-    public static StructureProcessorType<SmallNetherDungeonLegProcessor> SMALL_NETHER_DUNGEON_LEG_PROCESSOR = () -> SmallNetherDungeonLegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_LEG_PROCESSOR = SmallNetherDungeonLegProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_mob_spawner_processor")
-    public static StructureProcessorType<SmallNetherDungeonMobSpawner> SMALL_NETHER_DUNGEON_MOB_SPAWNER_PROCESSOR = () -> SmallNetherDungeonMobSpawner.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_MOB_SPAWNER_PROCESSOR = SmallNetherDungeonMobSpawner.CODEC;
 
     /* Skeleton dungeons */
     @AutoRegister("skeleton_dungeon_ruined_stone_bricks_processor")
-    public static StructureProcessorType<RuinedStoneBrickProcessor> SKELETON_DUNGEON_RUINED_STONE_BRICKS_PROCESSOR = () -> RuinedStoneBrickProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SKELETON_DUNGEON_RUINED_STONE_BRICKS_PROCESSOR = RuinedStoneBrickProcessor.CODEC;
 
     @AutoRegister("skeleton_mob_spawner_processor")
-    public static StructureProcessorType<SkeletonMobSpawnerProcessor> SKELETON_MOB_SPAWNER_PROCESSOR = () -> SkeletonMobSpawnerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SKELETON_MOB_SPAWNER_PROCESSOR = SkeletonMobSpawnerProcessor.CODEC;
 
     @AutoRegister("skeleton_dungeon_leg_processor")
-    public static StructureProcessorType<SkeletonDungeonLegProcessor> SKELETON_DUNGEON_LEG_PROCESSOR = () -> SkeletonDungeonLegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SKELETON_DUNGEON_LEG_PROCESSOR = SkeletonDungeonLegProcessor.CODEC;
 
     /* Zombie dungeons */
 
     @AutoRegister("zombie_dungeon_cubby_processor")
-    public static StructureProcessorType<ZombieDungeonCubbyProcessor> ZOMBIE_DUNGEON_CUBBY_PROCESSOR = () -> ZombieDungeonCubbyProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_DUNGEON_CUBBY_PROCESSOR = ZombieDungeonCubbyProcessor.CODEC;
 
     @AutoRegister("zombie_dungeon_stair_processor")
-    public static StructureProcessorType<ZombieDungeonStairProcessor> ZOMBIE_DUNGEON_STAIR_PROCESSOR = () -> ZombieDungeonStairProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_DUNGEON_STAIR_PROCESSOR = ZombieDungeonStairProcessor.CODEC;
 
     @AutoRegister("zombie_mob_spawner_processor")
-    public static StructureProcessorType<ZombieMobSpawnerProcessor> ZOMBIE_MOB_SPAWNER_PROCESSOR = () -> ZombieMobSpawnerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_MOB_SPAWNER_PROCESSOR = ZombieMobSpawnerProcessor.CODEC;
 
     @AutoRegister("zombie_tombstone_spawner_processor")
-    public static StructureProcessorType<ZombieTombstoneSpawnerProcessor> ZOMBIE_TOMBSTONE_SPAWNER_PROCESSOR = () -> ZombieTombstoneSpawnerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_TOMBSTONE_SPAWNER_PROCESSOR = ZombieTombstoneSpawnerProcessor.CODEC;
 
     @AutoRegister("zombie_main_stairs_processor")
-    public static StructureProcessorType<ZombieMainStairsProcessor> ZOMBIE_MAIN_STAIRS_PROCESSOR = () -> ZombieMainStairsProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_MAIN_STAIRS_PROCESSOR = ZombieMainStairsProcessor.CODEC;
 
     @AutoRegister("zombie_rot_processor")
-    public static StructureProcessorType<ZombieRotProcessor> ZOMBIE_ROT_PROCESSOR = () -> ZombieRotProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_ROT_PROCESSOR = ZombieRotProcessor.CODEC;
 
     @AutoRegister("zombie_dungeon_leg_processor")
-    public static StructureProcessorType<ZombieDungeonLegProcessor> ZOMBIE_DUNGEON_LEG_PROCESSOR = () -> ZombieDungeonLegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_DUNGEON_LEG_PROCESSOR = ZombieDungeonLegProcessor.CODEC;
 
     @AutoRegister("zombie_dungeon_flower_pot_processor")
-    public static StructureProcessorType<ZombieDungeonFlowerPotProcessor> ZOMBIE_DUNGEON_FLOWER_POT_PROCESSOR = () -> ZombieDungeonFlowerPotProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_DUNGEON_FLOWER_POT_PROCESSOR = ZombieDungeonFlowerPotProcessor.CODEC;
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/CandleProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/CandleProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
@@ -13,7 +13,6 @@ import net.minecraft.world.level.block.SeaPickleBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -21,30 +20,30 @@ import java.util.List;
 
 
 
-public class CandleProcessor extends StructureProcessor {
+public class CandleProcessor implements StructureProcessor {
     public static final CandleProcessor INSTANCE = new CandleProcessor();
     public static final MapCodec<CandleProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
-    private static final List<Block> CANDLES = List.of(Blocks.CANDLE, Blocks.WHITE_CANDLE, Blocks.GRAY_CANDLE,
-            Blocks.LIGHT_GRAY_CANDLE, Blocks.BROWN_CANDLE, Blocks.GREEN_CANDLE, Blocks.PURPLE_CANDLE, Blocks.BLACK_CANDLE);
+    private static final List<Block> CANDLES = List.of(Blocks.CANDLE, Blocks.DYED_CANDLE.pick(DyeColor.WHITE), Blocks.DYED_CANDLE.pick(DyeColor.GRAY),
+            Blocks.DYED_CANDLE.pick(DyeColor.LIGHT_GRAY), Blocks.DYED_CANDLE.pick(DyeColor.BROWN), Blocks.DYED_CANDLE.pick(DyeColor.GREEN), Blocks.DYED_CANDLE.pick(DyeColor.PURPLE), Blocks.DYED_CANDLE.pick(DyeColor.BLACK));
 
     @Override
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof SeaPickleBlock) {
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+        if (blockInfo.state().getBlock() instanceof SeaPickleBlock) {
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
             int numCandles = random.nextInt(4) + 1;
             boolean lit = random.nextFloat() < .1f;
             BlockState newBlockState = getRandomCandle(random).defaultBlockState()
                     .setValue(CandleBlock.CANDLES, numCandles)
                     .setValue(CandleBlock.LIT, lit);
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), newBlockState, blockInfoGlobal.nbt());
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), newBlockState, blockInfo.nbt());
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
     private static Block getRandomCandle(RandomSource random) {
@@ -52,7 +51,8 @@ public class CandleProcessor extends StructureProcessor {
         return CANDLES.get(i);
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.CANDLE_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/HeadProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/HeadProcessor.java
@@ -2,21 +2,19 @@ package com.yungnickyoung.minecraft.betterdungeons.world.processor;
 
 import com.mojang.serialization.MapCodec;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.AbstractSkullBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class HeadProcessor extends StructureProcessor {
+public class HeadProcessor implements StructureProcessor {
     public static final HeadProcessor INSTANCE = new HeadProcessor();
     public static final MapCodec<HeadProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -24,18 +22,19 @@ public class HeadProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof AbstractSkullBlock) {
+        if (blockInfo.state().getBlock() instanceof AbstractSkullBlock) {
             if (!BetterDungeonsCommon.CONFIG.general.enableHeads) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), blockInfoGlobal.nbt());
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), blockInfo.nbt());
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.HEAD_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/MobSpawnerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/MobSpawnerProcessor.java
@@ -3,7 +3,6 @@ package com.yungnickyoung.minecraft.betterdungeons.world.processor;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.world.spawner.MobSpawnerData;
 import net.minecraft.util.Util;
 import net.minecraft.core.BlockPos;
@@ -17,7 +16,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -28,7 +26,7 @@ import java.util.Optional;
  */
 
 
-public class MobSpawnerProcessor extends StructureProcessor {
+public class MobSpawnerProcessor implements StructureProcessor {
     public static final MapCodec<MobSpawnerProcessor> CODEC = RecordCodecBuilder.mapCodec(codecBuilder -> codecBuilder
             .group(
                     Identifier.CODEC
@@ -50,10 +48,10 @@ public class MobSpawnerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof SpawnerBlock) {
+        if (blockInfo.state().getBlock() instanceof SpawnerBlock) {
             // Create spawner & populate with data
             MobSpawnerData spawner = MobSpawnerData.builder()
                     .spawnPotentials(WeightedList.of(new SpawnData(
@@ -69,12 +67,13 @@ public class MobSpawnerProcessor extends StructureProcessor {
                             .value())
                     .build();
             CompoundTag nbt = spawner.save();
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.MOB_SPAWNER_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/NetherBlockProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/NetherBlockProcessor.java
@@ -2,7 +2,6 @@ package com.yungnickyoung.minecraft.betterdungeons.world.processor;
 
 import com.mojang.serialization.MapCodec;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
@@ -10,14 +9,13 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LanternBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class NetherBlockProcessor extends StructureProcessor {
+public class NetherBlockProcessor implements StructureProcessor {
     public static final NetherBlockProcessor INSTANCE = new NetherBlockProcessor();
     public static final MapCodec<NetherBlockProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,22 +23,23 @@ public class NetherBlockProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
         if (!BetterDungeonsCommon.CONFIG.general.enableNetherBlocks) {
-            if (blockInfoGlobal.state().is(Blocks.SOUL_SAND) || blockInfoGlobal.state().is(Blocks.SOUL_SOIL)) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.COARSE_DIRT.defaultBlockState(), null);
-            } else if (blockInfoGlobal.state().is(Blocks.SOUL_CAMPFIRE)) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAMPFIRE.defaultBlockState(), null);
-            } else if (blockInfoGlobal.state().is(Blocks.SOUL_LANTERN)) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.LANTERN.defaultBlockState().setValue(LanternBlock.HANGING, blockInfoGlobal.state().getValue(LanternBlock.HANGING)), null);
+            if (blockInfo.state().is(Blocks.SOUL_SAND) || blockInfo.state().is(Blocks.SOUL_SOIL)) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.COARSE_DIRT.defaultBlockState(), null);
+            } else if (blockInfo.state().is(Blocks.SOUL_CAMPFIRE)) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAMPFIRE.defaultBlockState(), null);
+            } else if (blockInfo.state().is(Blocks.SOUL_LANTERN)) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.LANTERN.defaultBlockState().setValue(LanternBlock.HANGING, blockInfo.state().getValue(LanternBlock.HANGING)), null);
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.NETHER_BLOCK_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/RuinedStoneBrickProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/RuinedStoneBrickProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.skeleton_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
 
 import net.minecraft.core.BlockPos;
@@ -11,7 +11,6 @@ import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -23,7 +22,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class RuinedStoneBrickProcessor extends StructureProcessor {
+public class RuinedStoneBrickProcessor implements StructureProcessor {
     public static final RuinedStoneBrickProcessor INSTANCE = new RuinedStoneBrickProcessor();
     public static final MapCodec<RuinedStoneBrickProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -38,26 +37,27 @@ public class RuinedStoneBrickProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.YELLOW_STAINED_GLASS) {
-            if (levelReader.getBlockState(blockInfoGlobal.pos()).isAir()) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+        if (blockInfo.state().getBlock() == Blocks.STAINED_GLASS.pick(DyeColor.YELLOW)) {
+            if (levelReader.getBlockState(blockInfo.pos()).isAir()) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             } else {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), STONE_BRICK_SELECTOR.get(structurePlacementData.getRandom(blockInfoGlobal.pos())), null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), STONE_BRICK_SELECTOR.get(structurePlacementData.getRandom(blockInfo.pos())), null);
             }
-        } else if (blockInfoGlobal.state().getBlock() == Blocks.PRISMARINE_BRICK_SLAB) {
-            if (levelReader.getBlockState(blockInfoGlobal.pos()).isAir()) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+        } else if (blockInfo.state().getBlock() == Blocks.PRISMARINE_BRICK_SLAB) {
+            if (levelReader.getBlockState(blockInfo.pos()).isAir()) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             } else {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), STONE_BRICK_SLAB_SELECTOR.get(structurePlacementData.getRandom(blockInfoGlobal.pos())), blockInfoGlobal.nbt());
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), STONE_BRICK_SLAB_SELECTOR.get(structurePlacementData.getRandom(blockInfo.pos())), blockInfo.nbt());
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SKELETON_DUNGEON_RUINED_STONE_BRICKS_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/SkeletonDungeonLegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/SkeletonDungeonLegProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.skeleton_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
 
 import net.minecraft.core.BlockPos;
@@ -14,7 +14,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -25,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class SkeletonDungeonLegProcessor extends StructureProcessor {
+public class SkeletonDungeonLegProcessor implements StructureProcessor {
     public static final SkeletonDungeonLegProcessor INSTANCE = new SkeletonDungeonLegProcessor();
     public static final MapCodec<SkeletonDungeonLegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -36,18 +35,18 @@ public class SkeletonDungeonLegProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.BLUE_STAINED_GLASS) {
-            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
-                return blockInfoGlobal;
+        if (blockInfo.state().getBlock() == Blocks.STAINED_GLASS.pick(DyeColor.BLUE)) {
+            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfo.pos()))) {
+                return blockInfo;
             }
 
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
 
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.COBBLESTONE.defaultBlockState(), null);
-            BlockPos.MutableBlockPos mutable = blockInfoGlobal.pos().mutable().move(Direction.DOWN);
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.COBBLESTONE.defaultBlockState(), null);
+            BlockPos.MutableBlockPos mutable = blockInfo.pos().mutable().move(Direction.DOWN);
             BlockState currBlockState = levelReader.getBlockState(mutable);
 
             while (mutable.getY() > levelReader.getMinY()
@@ -59,10 +58,11 @@ public class SkeletonDungeonLegProcessor extends StructureProcessor {
             }
         }
 
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SKELETON_DUNGEON_LEG_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/SkeletonMobSpawnerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/SkeletonMobSpawnerProcessor.java
@@ -1,7 +1,8 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.skeleton_dungeon;
+import net.minecraft.resources.Identifier;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.world.spawner.MobSpawnerData;
 
 import net.minecraft.util.Util;
@@ -15,7 +16,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -27,7 +27,7 @@ import java.util.Optional;
  */
 
 
-public class SkeletonMobSpawnerProcessor extends StructureProcessor {
+public class SkeletonMobSpawnerProcessor implements StructureProcessor {
     public static final SkeletonMobSpawnerProcessor INSTANCE = new SkeletonMobSpawnerProcessor();
     public static final MapCodec<SkeletonMobSpawnerProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -35,10 +35,10 @@ public class SkeletonMobSpawnerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof SpawnerBlock) {
+        if (blockInfo.state().getBlock() instanceof SpawnerBlock) {
             // Create spawner & populate with data
             MobSpawnerData spawner = MobSpawnerData.builder()
                     .spawnPotentials(WeightedList.of(new SpawnData(
@@ -48,15 +48,16 @@ public class SkeletonMobSpawnerProcessor extends StructureProcessor {
                     .requiredPlayerRange(18)
                     .maxNearbyEntities(8)
                     .maxSpawnDelay(650)
-                    .setEntityType(EntityType.SKELETON)
+                    .setEntityType(BuiltInRegistries.ENTITY_TYPE.get(Identifier.fromNamespaceAndPath("minecraft", "skeleton")).orElseThrow().value())
                     .build();
             CompoundTag nbt = spawner.save();
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SKELETON_MOB_SPAWNER_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonBannerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonBannerProcessor.java
@@ -4,7 +4,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.betterdungeons.world.DungeonContext;
 import com.yungnickyoung.minecraft.betterdungeons.world.DungeonType;
 import com.yungnickyoung.minecraft.yungsapi.world.banner.Banner;
@@ -22,7 +21,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import java.util.Objects;
@@ -34,7 +32,7 @@ import java.util.Objects;
  */
 
 
-public class SmallDungeonBannerProcessor extends StructureProcessor {
+public class SmallDungeonBannerProcessor implements StructureProcessor {
     public static final MapCodec<SmallDungeonBannerProcessor> CODEC = RecordCodecBuilder.mapCodec(codecBuilder -> codecBuilder
             .group(
                     Codec.STRING
@@ -54,7 +52,7 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
 
     // All banners
     public static final Banner SMALL_DUNGEON_SKELETON_BANNER = new Banner.Builder()
-            .blockState(Blocks.BLACK_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.pick(DyeColor.BLACK).defaultBlockState())
             .pattern(BannerPatterns.CURLY_BORDER, DyeColor.WHITE)
             .pattern(BannerPatterns.STRIPE_CENTER, DyeColor.WHITE)
             .pattern(BannerPatterns.STRIPE_BOTTOM, DyeColor.BLACK)
@@ -66,7 +64,7 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner SMALL_DUNGEON_ZOMBIE_BANNER = new Banner.Builder()
-            .blockState(Blocks.RED_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.pick(DyeColor.RED).defaultBlockState())
             .pattern(BannerPatterns.TRIANGLE_BOTTOM, DyeColor.PINK)
             .pattern(BannerPatterns.CIRCLE_MIDDLE, DyeColor.GRAY)
             .pattern(BannerPatterns.GRADIENT, DyeColor.BLACK)
@@ -78,7 +76,7 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner SMALL_DUNGEON_SPIDER_BANNER = new Banner.Builder()
-            .blockState(Blocks.RED_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.pick(DyeColor.RED).defaultBlockState())
             .pattern(BannerPatterns.FLOWER, DyeColor.GRAY)
             .pattern(BannerPatterns.BORDER, DyeColor.GRAY)
             .pattern(BannerPatterns.STRAIGHT_CROSS, DyeColor.GRAY)
@@ -93,41 +91,42 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof AbstractBannerBlock) {
+        if (blockInfo.state().getBlock() instanceof AbstractBannerBlock) {
             // Make sure we only operate on the placeholder banners
-            var globalNbt = Objects.requireNonNullElseGet(blockInfoGlobal.nbt(), CompoundTag::new);
-            if (blockInfoGlobal.state().getBlock() == Blocks.RED_WALL_BANNER &&
+            var globalNbt = Objects.requireNonNullElseGet(blockInfo.nbt(), CompoundTag::new);
+            if (blockInfo.state().getBlock() == Blocks.WALL_BANNER.pick(DyeColor.RED) &&
                 globalNbt.getList("patterns").filter(l -> !l.isEmpty()).isEmpty()) {
                 // Fetch thread-local dungeon context
                 DungeonContext context = DungeonContext.peek();
 
                 // Check dungeon context to see if we have reached the max banner count for this structure piece
                 if (context.getBannerCount() >= BetterDungeonsCommon.CONFIG.smallDungeons.bannerMaxCount)
-                    return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+                    return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
 
                 // Chance of a banner spawning
-                RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+                RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
                 if (random.nextFloat() > .1f) {
-                    return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+                    return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
                 }
 
                 Banner banner = getBannerForType();
-                Direction facing = blockInfoGlobal.state().getValue(BlockStateProperties.HORIZONTAL_FACING);
+                Direction facing = blockInfo.state().getValue(BlockStateProperties.HORIZONTAL_FACING);
                 BlockState newState = banner.getState().setValue(BlockStateProperties.HORIZONTAL_FACING, facing);
                 CompoundTag newNBT = copyNBT(banner.getNbt());
 
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), newState, newNBT);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), newState, newNBT);
                 context.incrementBannerCount();
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_DUNGEON_BANNER_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 
     private Banner getBannerForType() {

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingLampPropProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingLampPropProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
@@ -9,12 +9,11 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
 
-public class SmallDungeonCeilingLampPropProcessor extends StructureProcessor {
+public class SmallDungeonCeilingLampPropProcessor implements StructureProcessor {
     public static final SmallDungeonCeilingLampPropProcessor INSTANCE = new SmallDungeonCeilingLampPropProcessor();
     public static final MapCodec<SmallDungeonCeilingLampPropProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -22,25 +21,26 @@ public class SmallDungeonCeilingLampPropProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.CYAN_STAINED_GLASS)) {
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+        if (blockInfo.state().is(Blocks.STAINED_GLASS.pick(DyeColor.CYAN))) {
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
 
             // Choose lamp prop
             float f = random.nextFloat();
             if (f < 0.625f) { // Chain
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.IRON_CHAIN.defaultBlockState(), null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.IRON_CHAIN.defaultBlockState(), null);
             } else { // None
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
         }
 
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_DUNGEON_CEILING_LAMP_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.FluidTags;
@@ -9,7 +9,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
@@ -18,7 +17,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class SmallDungeonCeilingProcessor extends StructureProcessor {
+public class SmallDungeonCeilingProcessor implements StructureProcessor {
     public static final SmallDungeonCeilingProcessor INSTANCE = new SmallDungeonCeilingProcessor();
     public static final MapCodec<SmallDungeonCeilingProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -26,20 +25,21 @@ public class SmallDungeonCeilingProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.ORANGE_STAINED_GLASS) {
-            if (levelReader.getFluidState(blockInfoGlobal.pos()).is(FluidTags.WATER) || levelReader.getFluidState(blockInfoGlobal.pos()).is(FluidTags.LAVA)) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.COBBLESTONE.defaultBlockState(), null);
+        if (blockInfo.state().getBlock() == Blocks.STAINED_GLASS.pick(DyeColor.ORANGE)) {
+            if (levelReader.getFluidState(blockInfo.pos()).is(FluidTags.WATER) || levelReader.getFluidState(blockInfo.pos()).is(FluidTags.LAVA)) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.COBBLESTONE.defaultBlockState(), null);
             } else {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), levelReader.getBlockState(blockInfoGlobal.pos()), null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), levelReader.getBlockState(blockInfo.pos()), null);
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_DUNGEON_CEILING_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingPropProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingPropProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -10,12 +10,11 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
 
-public class SmallDungeonCeilingPropProcessor extends StructureProcessor {
+public class SmallDungeonCeilingPropProcessor implements StructureProcessor {
     public static final SmallDungeonCeilingPropProcessor INSTANCE = new SmallDungeonCeilingPropProcessor();
     public static final MapCodec<SmallDungeonCeilingPropProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -23,44 +22,45 @@ public class SmallDungeonCeilingPropProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.MAGENTA_STAINED_GLASS)) {
+        if (blockInfo.state().is(Blocks.STAINED_GLASS.pick(DyeColor.MAGENTA))) {
             // If ceiling isn't solid, place air since we don't want floating props
-            if (!levelReader.getBlockState(blockInfoGlobal.pos().above()).isFaceSturdy(levelReader, blockInfoGlobal.pos().above(), Direction.DOWN)) {
-                return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+            if (!levelReader.getBlockState(blockInfo.pos().above()).isFaceSturdy(levelReader, blockInfo.pos().above(), Direction.DOWN)) {
+                return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
 
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
             float f = random.nextFloat();
 
             // Choose ceiling prop
-            if (f < .2f) blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.IRON_CHAIN.defaultBlockState(), blockInfoGlobal.nbt());
-            else blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), blockInfoGlobal.nbt());
-        } else if (blockInfoGlobal.state().is(Blocks.BROWN_STAINED_GLASS)) {
+            if (f < .2f) blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.IRON_CHAIN.defaultBlockState(), blockInfo.nbt());
+            else blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), blockInfo.nbt());
+        } else if (blockInfo.state().is(Blocks.STAINED_GLASS.pick(DyeColor.BROWN))) {
             // If ceiling isn't solid, simply ignore processing since we don't want floating props
-            if (!levelReader.getBlockState(blockInfoGlobal.pos().above(2)).isFaceSturdy(levelReader, blockInfoGlobal.pos().above(), Direction.DOWN)) {
-                return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+            if (!levelReader.getBlockState(blockInfo.pos().above(2)).isFaceSturdy(levelReader, blockInfo.pos().above(), Direction.DOWN)) {
+                return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
 
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
             float f = random.nextFloat();
 
             // Choose ceiling prop
-            if (f < .5f) blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.IRON_CHAIN.defaultBlockState(), blockInfoGlobal.nbt());
-            else blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), blockInfoGlobal.nbt());
-        } else if (blockInfoGlobal.state().is(Blocks.IRON_CHAIN)) {
+            if (f < .5f) blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.IRON_CHAIN.defaultBlockState(), blockInfo.nbt());
+            else blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), blockInfo.nbt());
+        } else if (blockInfo.state().is(Blocks.IRON_CHAIN)) {
             // If ceiling isn't solid, don't place top chains for potential double chains if they would be floating
-            if (!levelReader.getBlockState(blockInfoGlobal.pos().above()).isFaceSturdy(levelReader, blockInfoGlobal.pos().above(), Direction.DOWN)) {
-                return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+            if (!levelReader.getBlockState(blockInfo.pos().above()).isFaceSturdy(levelReader, blockInfo.pos().above(), Direction.DOWN)) {
+                return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
         }
 
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_DUNGEON_CEILING_PROP_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonChestProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonChestProcessor.java
@@ -2,7 +2,6 @@ package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_dungeon
 
 import com.mojang.serialization.MapCodec;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.betterdungeons.world.DungeonContext;
 
 import net.minecraft.core.BlockPos;
@@ -12,7 +11,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ChestBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
@@ -20,7 +18,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class SmallDungeonChestProcessor extends StructureProcessor {
+public class SmallDungeonChestProcessor implements StructureProcessor {
     public static final SmallDungeonChestProcessor INSTANCE = new SmallDungeonChestProcessor();
     public static final MapCodec<SmallDungeonChestProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -28,10 +26,10 @@ public class SmallDungeonChestProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof ChestBlock) {
+        if (blockInfo.state().getBlock() instanceof ChestBlock) {
             // Fetch thread-local dungeon context
             DungeonContext context = DungeonContext.peek();
             int chestCount = DungeonContext.peek().getChestCount();
@@ -39,19 +37,20 @@ public class SmallDungeonChestProcessor extends StructureProcessor {
             if (chestCount < BetterDungeonsCommon.CONFIG.smallDungeons.chestMinCount) { // Ensure there is at least minimum amount of chests
                 context.incrementChestCount();
             } else if (chestCount < BetterDungeonsCommon.CONFIG.smallDungeons.chestMaxCount) { // 20% chance of additional chest, per chest prop
-                RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+                RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
                 if (random.nextFloat() > .2f) {
-                    return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+                    return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
                 }
                 context.incrementChestCount();
             } else { // Can't spawn more than max chests
-                return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+                return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_DUNGEON_CHEST_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCobblestoneProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCobblestoneProcessor.java
@@ -1,14 +1,12 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_dungeon;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
@@ -17,7 +15,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class SmallDungeonCobblestoneProcessor extends StructureProcessor {
+public class SmallDungeonCobblestoneProcessor implements StructureProcessor {
     public static final SmallDungeonCobblestoneProcessor INSTANCE = new SmallDungeonCobblestoneProcessor();
     public static final MapCodec<SmallDungeonCobblestoneProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,18 +23,19 @@ public class SmallDungeonCobblestoneProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE) {
-            if (levelReader.getBlockState(blockInfoGlobal.pos()).isAir()) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+        if (blockInfo.state().getBlock() == Blocks.COBBLESTONE) {
+            if (levelReader.getBlockState(blockInfo.pos()).isAir()) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_DUNGEON_COBBLE_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonLegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonLegProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
 
 import net.minecraft.core.BlockPos;
@@ -14,7 +14,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -25,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class SmallDungeonLegProcessor extends StructureProcessor {
+public class SmallDungeonLegProcessor implements StructureProcessor {
     public static final SmallDungeonLegProcessor INSTANCE = new SmallDungeonLegProcessor();
     public static final MapCodec<SmallDungeonLegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -37,18 +36,18 @@ public class SmallDungeonLegProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.YELLOW_STAINED_GLASS) {
-            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
-                return blockInfoGlobal;
+        if (blockInfo.state().getBlock() == Blocks.STAINED_GLASS.pick(DyeColor.YELLOW)) {
+            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfo.pos()))) {
+                return blockInfo;
             }
 
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
 
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.MOSSY_COBBLESTONE.defaultBlockState(), null);
-            BlockPos.MutableBlockPos mutable = blockInfoGlobal.pos().mutable().move(Direction.DOWN);
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.MOSSY_COBBLESTONE.defaultBlockState(), null);
+            BlockPos.MutableBlockPos mutable = blockInfo.pos().mutable().move(Direction.DOWN);
             BlockState currBlockState = levelReader.getBlockState(mutable);
 
             while (mutable.getY() > levelReader.getMinY()
@@ -60,10 +59,11 @@ public class SmallDungeonLegProcessor extends StructureProcessor {
             }
         }
 
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_DUNGEON_LEG_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonOreProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonOreProcessor.java
@@ -2,7 +2,6 @@ package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_dungeon
 
 import com.mojang.serialization.MapCodec;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.BlockTags;
@@ -11,7 +10,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import java.util.function.Predicate;
@@ -21,36 +19,32 @@ import java.util.function.Predicate;
  */
 
 
-public class SmallDungeonOreProcessor extends StructureProcessor {
+public class SmallDungeonOreProcessor implements StructureProcessor {
     public static final SmallDungeonOreProcessor INSTANCE = new SmallDungeonOreProcessor();
     public static final MapCodec<SmallDungeonOreProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
     private static final Predicate<BlockState> isOre = blockState ->
             blockState.is(BlockTags.GOLD_ORES) ||
             blockState.is(BlockTags.IRON_ORES) ||
-            blockState.is(BlockTags.DIAMOND_ORES) ||
-            blockState.is(BlockTags.REDSTONE_ORES) ||
-            blockState.is(BlockTags.LAPIS_ORES) ||
-            blockState.is(BlockTags.COAL_ORES) ||
-            blockState.is(BlockTags.EMERALD_ORES) ||
             blockState.is(BlockTags.COPPER_ORES);
 
     @Override
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (isOre.test(blockInfoGlobal.state())) {
+        if (isOre.test(blockInfo.state())) {
             if (!BetterDungeonsCommon.CONFIG.smallDungeons.enableOreProps) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_DUNGEON_ORE_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonBannerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonBannerProcessor.java
@@ -4,7 +4,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.betterdungeons.world.DungeonContext;
 import com.yungnickyoung.minecraft.betterdungeons.world.DungeonType;
 import com.yungnickyoung.minecraft.yungsapi.world.banner.Banner;
@@ -22,7 +21,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -35,7 +33,7 @@ import java.util.Objects;
  */
 
 
-public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
+public class SmallNetherDungeonBannerProcessor implements StructureProcessor {
     public static final MapCodec<SmallNetherDungeonBannerProcessor> CODEC = RecordCodecBuilder.mapCodec(codecBuilder -> codecBuilder
             .group(
                     Codec.STRING
@@ -55,7 +53,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
 
     // All banners
     public static final Banner SKELETON_BANNER = new Banner.Builder()
-            .blockState(Blocks.BLACK_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.pick(DyeColor.BLACK).defaultBlockState())
             .pattern(BannerPatterns.CURLY_BORDER, DyeColor.WHITE)
             .pattern(BannerPatterns.STRIPE_CENTER, DyeColor.WHITE)
             .pattern(BannerPatterns.STRIPE_BOTTOM, DyeColor.BLACK)
@@ -67,7 +65,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner WITHER_SKELETON_BANNER = new Banner.Builder()
-            .blockState(Blocks.RED_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.pick(DyeColor.RED).defaultBlockState())
             .pattern(BannerPatterns.CURLY_BORDER, DyeColor.BLACK)
             .pattern(BannerPatterns.STRIPE_CENTER, DyeColor.BLACK)
             .pattern(BannerPatterns.STRIPE_BOTTOM, DyeColor.RED)
@@ -79,7 +77,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner ZOMBIFIED_PIGLIN_BANNER = new Banner.Builder()
-            .blockState(Blocks.PINK_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.pick(DyeColor.PINK).defaultBlockState())
             .pattern(BannerPatterns.STRIPE_LEFT, DyeColor.GREEN)
             .pattern(BannerPatterns.TRIANGLES_TOP, DyeColor.BLACK)
             .pattern(BannerPatterns.TRIANGLES_TOP, DyeColor.PINK)
@@ -97,7 +95,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner BLAZE_BANNER = new Banner.Builder()
-            .blockState(Blocks.RED_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.pick(DyeColor.RED).defaultBlockState())
             .pattern(BannerPatterns.STRIPE_SMALL, DyeColor.YELLOW)
             .pattern(BannerPatterns.TRIANGLE_TOP, DyeColor.RED)
             .pattern(BannerPatterns.TRIANGLE_TOP, DyeColor.RED)
@@ -113,41 +111,42 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof AbstractBannerBlock) {
+        if (blockInfo.state().getBlock() instanceof AbstractBannerBlock) {
             // Make sure we only operate on the placeholder banners
-            var globalNbt = Objects.requireNonNullElseGet(blockInfoGlobal.nbt(), CompoundTag::new);
-            if (blockInfoGlobal.state().getBlock() == Blocks.GRAY_WALL_BANNER &&
+            var globalNbt = Objects.requireNonNullElseGet(blockInfo.nbt(), CompoundTag::new);
+            if (blockInfo.state().getBlock() == Blocks.WALL_BANNER.pick(DyeColor.GRAY) &&
                 globalNbt.getList("patterns").filter(l -> !l.isEmpty()).isEmpty()) {
                 // Fetch thread-local dungeon context
                 DungeonContext context = DungeonContext.peek();
 
                 // Check dungeon context to see if we have reached the max banner count for this structure piece
                 if (context.getBannerCount() >= BetterDungeonsCommon.CONFIG.smallNetherDungeons.bannerMaxCount)
-                    return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.AIR.defaultBlockState(), null);
+                    return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.AIR.defaultBlockState(), null);
 
                 // Chance of a banner spawning
-                RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+                RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
                 if (random.nextFloat() > .1f) {
-                    return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.AIR.defaultBlockState(), null);
+                    return new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.AIR.defaultBlockState(), null);
                 }
 
                 Banner banner = getBannerForType();
-                Direction facing = blockInfoGlobal.state().getValue(BlockStateProperties.HORIZONTAL_FACING);
+                Direction facing = blockInfo.state().getValue(BlockStateProperties.HORIZONTAL_FACING);
                 BlockState newState = banner.getState().setValue(BlockStateProperties.HORIZONTAL_FACING, facing);
                 CompoundTag newNBT = copyNBT(banner.getNbt());
 
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), newState, newNBT);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), newState, newNBT);
                 context.incrementBannerCount();
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_BANNER_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 
     private Banner getBannerForType() {

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonEntranceStairsProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonEntranceStairsProcessor.java
@@ -1,7 +1,6 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_nether_dungeon;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -12,14 +11,13 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.StairBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class SmallNetherDungeonEntranceStairsProcessor extends StructureProcessor {
+public class SmallNetherDungeonEntranceStairsProcessor implements StructureProcessor {
     public static final SmallNetherDungeonEntranceStairsProcessor INSTANCE = new SmallNetherDungeonEntranceStairsProcessor();
     public static final MapCodec<SmallNetherDungeonEntranceStairsProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -27,27 +25,28 @@ public class SmallNetherDungeonEntranceStairsProcessor extends StructureProcesso
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.BRICK_STAIRS)) {
-            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
-                return blockInfoGlobal;
+        if (blockInfo.state().is(Blocks.BRICK_STAIRS)) {
+            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfo.pos()))) {
+                return blockInfo;
             }
-            Direction facing = blockInfoGlobal.state().hasProperty(StairBlock.FACING)
-                    ? blockInfoGlobal.state().getValue(StairBlock.FACING)
+            Direction facing = blockInfo.state().hasProperty(StairBlock.FACING)
+                    ? blockInfo.state().getValue(StairBlock.FACING)
                     : Direction.NORTH;
             facing = structurePlacementData.getRotation().rotate(facing);
-            BlockPos pos = blockInfoGlobal.pos().relative(facing);
+            BlockPos pos = blockInfo.pos().relative(facing);
             levelReader.getChunk(pos).setBlockState(pos, Blocks.NETHER_BRICK_STAIRS
-                    .withPropertiesOf(blockInfoGlobal.state())
+                    .withPropertiesOf(blockInfo.state())
                     .setValue(StairBlock.FACING, facing.getOpposite()));
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.NETHER_BRICKS.defaultBlockState(), blockInfoGlobal.nbt());
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.NETHER_BRICKS.defaultBlockState(), blockInfo.nbt());
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_ENTRANCE_STAIRS_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonHeadProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonHeadProcessor.java
@@ -2,7 +2,6 @@ package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_nether_
 
 import com.mojang.serialization.MapCodec;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
@@ -10,14 +9,13 @@ import net.minecraft.world.level.block.AbstractSkullBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class SmallNetherDungeonHeadProcessor extends StructureProcessor {
+public class SmallNetherDungeonHeadProcessor implements StructureProcessor {
     public static final SmallNetherDungeonHeadProcessor INSTANCE = new SmallNetherDungeonHeadProcessor();
     public static final MapCodec<SmallNetherDungeonHeadProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,18 +23,19 @@ public class SmallNetherDungeonHeadProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof AbstractSkullBlock) {
-            if (!BetterDungeonsCommon.CONFIG.general.enableHeads || structurePlacementData.getRandom(blockInfoGlobal.pos()).nextFloat() > 0.167) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.AIR.defaultBlockState(), null);
+        if (blockInfo.state().getBlock() instanceof AbstractSkullBlock) {
+            if (!BetterDungeonsCommon.CONFIG.general.enableHeads || structurePlacementData.getRandom(blockInfo.pos()).nextFloat() > 0.167) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.AIR.defaultBlockState(), null);
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_HEAD_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonLavaBlockProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonLavaBlockProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_nether_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.WorldGenRegion;
@@ -10,14 +10,13 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class SmallNetherDungeonLavaBlockProcessor extends StructureProcessor {
+public class SmallNetherDungeonLavaBlockProcessor implements StructureProcessor {
     public static final SmallNetherDungeonLavaBlockProcessor INSTANCE = new SmallNetherDungeonLavaBlockProcessor();
     public static final MapCodec<SmallNetherDungeonLavaBlockProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,20 +24,21 @@ public class SmallNetherDungeonLavaBlockProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.ORANGE_WOOL)) {
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.LAVA.defaultBlockState(), null);
-            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
-                return blockInfoGlobal;
+        if (blockInfo.state().is(Blocks.WOOL.pick(DyeColor.ORANGE))) {
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.LAVA.defaultBlockState(), null);
+            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfo.pos()))) {
+                return blockInfo;
             }
-            levelReader.getChunk(blockInfoGlobal.pos()).markPosForPostprocessing(blockInfoGlobal.pos()); // Schedule fluid tick
+            levelReader.getChunk(blockInfo.pos()).markPosForPostProcessing(blockInfo.pos()); // Schedule fluid tick
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_LAVA_BLOCK_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonLegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonLegProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_nether_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -12,7 +12,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -23,7 +22,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class SmallNetherDungeonLegProcessor extends StructureProcessor {
+public class SmallNetherDungeonLegProcessor implements StructureProcessor {
     public static final SmallNetherDungeonLegProcessor INSTANCE = new SmallNetherDungeonLegProcessor();
     public static final MapCodec<SmallNetherDungeonLegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -31,16 +30,16 @@ public class SmallNetherDungeonLegProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.ORANGE_TERRACOTTA) {
-            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
-                return blockInfoGlobal;
+        if (blockInfo.state().getBlock() == Blocks.DYED_TERRACOTTA.pick(DyeColor.ORANGE)) {
+            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfo.pos()))) {
+                return blockInfo;
             }
 
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.NETHER_BRICKS.defaultBlockState(), null);
-            BlockPos.MutableBlockPos mutable = blockInfoGlobal.pos().mutable().move(Direction.DOWN);
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.NETHER_BRICKS.defaultBlockState(), null);
+            BlockPos.MutableBlockPos mutable = blockInfo.pos().mutable().move(Direction.DOWN);
             BlockState currBlockState = levelReader.getBlockState(mutable);
 
             while (mutable.getY() > levelReader.getMinY()
@@ -52,10 +51,11 @@ public class SmallNetherDungeonLegProcessor extends StructureProcessor {
             }
         }
 
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_LEG_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonMobSpawner.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonMobSpawner.java
@@ -3,7 +3,6 @@ package com.yungnickyoung.minecraft.betterdungeons.world.processor.small_nether_
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.world.spawner.MobSpawnerData;
 
 import net.minecraft.util.Util;
@@ -24,7 +23,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -32,7 +30,7 @@ import java.util.Optional;
 
 
 
-public class SmallNetherDungeonMobSpawner extends StructureProcessor {
+public class SmallNetherDungeonMobSpawner implements StructureProcessor {
     public static final MapCodec<SmallNetherDungeonMobSpawner> CODEC = RecordCodecBuilder.mapCodec(codecBuilder -> codecBuilder
             .group(
                     Identifier.CODEC
@@ -54,10 +52,10 @@ public class SmallNetherDungeonMobSpawner extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof SpawnerBlock) {
+        if (blockInfo.state().getBlock() instanceof SpawnerBlock) {
             // Create spawner & populate with data
             MobSpawnerData spawner = MobSpawnerData.builder()
                     .spawnPotentials(WeightedList.of(new SpawnData(
@@ -147,12 +145,13 @@ public class SmallNetherDungeonMobSpawner extends StructureProcessor {
                 }
             }
             CompoundTag nbt = spawner.save();
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_MOB_SPAWNER_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonCubbyProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonCubbyProcessor.java
@@ -1,7 +1,6 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
 
 import net.minecraft.core.BlockPos;
@@ -14,7 +13,6 @@ import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -24,7 +22,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class ZombieDungeonCubbyProcessor extends StructureProcessor {
+public class ZombieDungeonCubbyProcessor implements StructureProcessor {
     public static final ZombieDungeonCubbyProcessor INSTANCE = new ZombieDungeonCubbyProcessor();
     public static final MapCodec<ZombieDungeonCubbyProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -37,29 +35,30 @@ public class ZombieDungeonCubbyProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
-            BlockState newBlock = SELECTOR.get(structurePlacementData.getRandom(blockInfoGlobal.pos()));
+        if (blockInfo.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
+            BlockState newBlock = SELECTOR.get(structurePlacementData.getRandom(blockInfo.pos()));
             if (newBlock.getBlock() instanceof StairBlock) {
                 newBlock = newBlock
-                    .setValue(StairBlock.FACING, blockInfoGlobal.state().getValue(StairBlock.FACING))
-                    .setValue(StairBlock.HALF, blockInfoGlobal.state().getValue(StairBlock.HALF))
-                    .setValue(StairBlock.SHAPE, blockInfoGlobal.state().getValue(StairBlock.SHAPE));
+                    .setValue(StairBlock.FACING, blockInfo.state().getValue(StairBlock.FACING))
+                    .setValue(StairBlock.HALF, blockInfo.state().getValue(StairBlock.HALF))
+                    .setValue(StairBlock.SHAPE, blockInfo.state().getValue(StairBlock.SHAPE));
             }
             if (newBlock.getBlock() instanceof SlabBlock) {
-                if (blockInfoGlobal.state().getValue(StairBlock.HALF) == Half.TOP) {
+                if (blockInfo.state().getValue(StairBlock.HALF) == Half.TOP) {
                     newBlock = newBlock.setValue(SlabBlock.TYPE, SlabType.TOP);
                 }
             }
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), newBlock, blockInfoGlobal.nbt());
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), newBlock, blockInfo.nbt());
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.ZOMBIE_DUNGEON_CUBBY_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }
 

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonFlowerPotProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonFlowerPotProcessor.java
@@ -1,7 +1,6 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
 
 import net.minecraft.core.BlockPos;
@@ -10,14 +9,13 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class ZombieDungeonFlowerPotProcessor extends StructureProcessor {
+public class ZombieDungeonFlowerPotProcessor implements StructureProcessor {
     public static final ZombieDungeonFlowerPotProcessor INSTANCE = new ZombieDungeonFlowerPotProcessor();
     public static final MapCodec<ZombieDungeonFlowerPotProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -33,18 +31,19 @@ public class ZombieDungeonFlowerPotProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.POTTED_CORNFLOWER)) {
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), FLOWER_SELECTOR.get(random), blockInfoGlobal.nbt());
+        if (blockInfo.state().is(Blocks.POTTED_CORNFLOWER)) {
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), FLOWER_SELECTOR.get(random), blockInfo.nbt());
         }
 
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.ZOMBIE_DUNGEON_FLOWER_POT_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonLegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonLegProcessor.java
@@ -1,7 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
 import com.yungnickyoung.minecraft.yungsapi.world.structure.processor.ISafeWorldModifier;
 
@@ -15,7 +15,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -28,7 +27,7 @@ import java.util.Optional;
  */
 
 
-public class ZombieDungeonLegProcessor extends StructureProcessor implements ISafeWorldModifier {
+public class ZombieDungeonLegProcessor implements StructureProcessor,  ISafeWorldModifier {
     public static final ZombieDungeonLegProcessor INSTANCE = new ZombieDungeonLegProcessor();
     public static final MapCodec<ZombieDungeonLegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -39,25 +38,25 @@ public class ZombieDungeonLegProcessor extends StructureProcessor implements ISa
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.MAGENTA_STAINED_GLASS) {
-            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
-                return blockInfoGlobal;
+        if (blockInfo.state().getBlock() == Blocks.STAINED_GLASS.pick(DyeColor.MAGENTA)) {
+            if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfo.pos()))) {
+                return blockInfo;
             }
 
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
 
             // Always replace the glass itself with smooth stone
-            Optional<BlockState> blockState = getBlockStateSafe(levelReader, blockInfoGlobal.pos());
+            Optional<BlockState> blockState = getBlockStateSafe(levelReader, blockInfo.pos());
             if (blockState.isEmpty() || blockState.get().isAir() || blockState.get().liquid()) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SMOOTH_STONE.defaultBlockState(), null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.SMOOTH_STONE.defaultBlockState(), null);
             } else {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), blockState.get(), blockInfoGlobal.nbt());
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), blockState.get(), blockInfo.nbt());
             }
 
-            BlockPos.MutableBlockPos mutable = blockInfoGlobal.pos().mutable().move(Direction.DOWN);
+            BlockPos.MutableBlockPos mutable = blockInfo.pos().mutable().move(Direction.DOWN);
             BlockState currBlockState = levelReader.getBlockState(mutable);
 
             // Generate vertical pillar down
@@ -68,19 +67,20 @@ public class ZombieDungeonLegProcessor extends StructureProcessor implements ISa
                 mutable.move(Direction.DOWN);
                 currBlockState = levelReader.getBlockState(mutable);
             }
-        } else if (blockInfoGlobal.state().getBlock() == Blocks.PURPUR_SLAB) {
-            Optional<BlockState> blockState = getBlockStateSafe(levelReader, blockInfoGlobal.pos());
+        } else if (blockInfo.state().getBlock() == Blocks.PURPUR_SLAB) {
+            Optional<BlockState> blockState = getBlockStateSafe(levelReader, blockInfo.pos());
             if (blockState.isEmpty() || blockState.get().isAir() || blockState.get().liquid()) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SMOOTH_STONE_SLAB.defaultBlockState(), null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.SMOOTH_STONE_SLAB.defaultBlockState(), null);
             } else {
-                blockInfoGlobal = null;
+                blockInfo = null;
             }
         }
 
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.ZOMBIE_DUNGEON_LEG_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonStairProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonStairProcessor.java
@@ -1,7 +1,6 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
 
 import net.minecraft.core.BlockPos;
@@ -11,7 +10,6 @@ import net.minecraft.world.level.block.StairBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -21,7 +19,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class ZombieDungeonStairProcessor extends StructureProcessor {
+public class ZombieDungeonStairProcessor implements StructureProcessor {
     public static final ZombieDungeonStairProcessor INSTANCE = new ZombieDungeonStairProcessor();
     public static final MapCodec<ZombieDungeonStairProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -37,28 +35,29 @@ public class ZombieDungeonStairProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
-            if (levelReader.getBlockState(blockInfoGlobal.pos()).isAir()) {
+        if (blockInfo.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
+            if (levelReader.getBlockState(blockInfo.pos()).isAir()) {
                 // Don't replace air to maintain rotted look
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             } else {
-                BlockState newBlock = SELECTOR.get(structurePlacementData.getRandom(blockInfoGlobal.pos()));
+                BlockState newBlock = SELECTOR.get(structurePlacementData.getRandom(blockInfo.pos()));
                 if (newBlock.getBlock() instanceof StairBlock) {
                     newBlock = newBlock
-                        .setValue(StairBlock.FACING, blockInfoGlobal.state().getValue(StairBlock.FACING))
-                        .setValue(StairBlock.HALF, blockInfoGlobal.state().getValue(StairBlock.HALF))
-                        .setValue(StairBlock.SHAPE, blockInfoGlobal.state().getValue(StairBlock.SHAPE));
+                        .setValue(StairBlock.FACING, blockInfo.state().getValue(StairBlock.FACING))
+                        .setValue(StairBlock.HALF, blockInfo.state().getValue(StairBlock.HALF))
+                        .setValue(StairBlock.SHAPE, blockInfo.state().getValue(StairBlock.SHAPE));
                 }
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), newBlock, null);
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), newBlock, null);
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.ZOMBIE_DUNGEON_STAIR_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieMainStairsProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieMainStairsProcessor.java
@@ -2,7 +2,6 @@ package com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeo
 
 import com.mojang.serialization.MapCodec;
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
 import com.yungnickyoung.minecraft.yungsapi.world.structure.processor.ISafeWorldModifier;
 
@@ -19,7 +18,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -30,7 +28,7 @@ import java.util.Optional;
  */
 
 
-public class ZombieMainStairsProcessor extends StructureProcessor implements ISafeWorldModifier {
+public class ZombieMainStairsProcessor implements StructureProcessor,  ISafeWorldModifier {
     public static final ZombieMainStairsProcessor INSTANCE = new ZombieMainStairsProcessor();
     public static final MapCodec<ZombieMainStairsProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -49,36 +47,36 @@ public class ZombieMainStairsProcessor extends StructureProcessor implements ISa
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.WARPED_STAIRS) { // Warped stairs are the marker for the main staircase
-            BlockPos.MutableBlockPos temp = blockInfoGlobal.pos().mutable();
-            Direction facing = structurePlacementData.getRotation().rotate(blockInfoGlobal.state().getValue(StairBlock.FACING));
+        if (blockInfo.state().getBlock() == Blocks.WARPED_STAIRS) { // Warped stairs are the marker for the main staircase
+            BlockPos.MutableBlockPos temp = blockInfo.pos().mutable();
+            Direction facing = structurePlacementData.getRotation().rotate(blockInfo.state().getValue(StairBlock.FACING));
             Rotation rotation = structurePlacementData.getRotation().getRotated(Rotation.CLOCKWISE_180);
 
             // Check if the surface is close enough to warrant a staircase
             int maxLength = BetterDungeonsCommon.CONFIG.zombieDungeons.zombieDungeonMaxSurfaceStaircaseLength; // Max distance our staircase can go horizontally
 
             // The highest allowable position at the end of the staircase
-            BlockPos maxSurfacePos = blockInfoGlobal.pos().relative(facing, maxLength).relative(Direction.UP, maxLength);
+            BlockPos maxSurfacePos = blockInfo.pos().relative(facing, maxLength).relative(Direction.UP, maxLength);
 
             // Get the surface height at the end of the staircase
             temp.move(facing, maxLength);
             int surfaceHeight = levelReader.getHeight(Heightmap.Types.WORLD_SURFACE_WG, temp.getX(), temp.getZ());
 
             // Don't spawn staircase if we won't penetrate the surface
-            if (surfaceHeight >= maxSurfacePos.getY() || surfaceHeight <= blockInfoGlobal.pos().getY()) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
-                return blockInfoGlobal;
+            if (surfaceHeight >= maxSurfacePos.getY() || surfaceHeight <= blockInfo.pos().getY()) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+                return blockInfo;
             }
 
             // Begin spawning staircase
-            RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
+            RandomSource random = structurePlacementData.getRandom(blockInfo.pos());
 
-            BlockPos.MutableBlockPos leftPos = new BlockPos(blockInfoGlobal.pos().relative(facing.getCounterClockWise())).mutable();
-            BlockPos.MutableBlockPos middlePos = new BlockPos(blockInfoGlobal.pos()).mutable();
-            BlockPos.MutableBlockPos rightPos = new BlockPos(blockInfoGlobal.pos().relative(facing.getClockWise())).mutable();
+            BlockPos.MutableBlockPos leftPos = new BlockPos(blockInfo.pos().relative(facing.getCounterClockWise())).mutable();
+            BlockPos.MutableBlockPos middlePos = new BlockPos(blockInfo.pos()).mutable();
+            BlockPos.MutableBlockPos rightPos = new BlockPos(blockInfo.pos().relative(facing.getClockWise())).mutable();
             BlockState tempBlock;
             Optional<BlockState> tempOptional;
 
@@ -292,13 +290,14 @@ public class ZombieMainStairsProcessor extends StructureProcessor implements ISa
             this.setBlockStateRandom(levelReader, tombSelector.get(random), rightPos, structurePlacementData.getMirror(), rotation, random, .5f);
 
             // Always replace the warped stair marker with air
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), STAIR_SELECTOR.get(random), blockInfoGlobal.nbt());
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), STAIR_SELECTOR.get(random), blockInfo.nbt());
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.ZOMBIE_MAIN_STAIRS_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 
     private void setBlockStateSafeWithPlacement(LevelReader levelReader, BlockState blockState, BlockPos pos, Mirror mirror, Rotation rotation) {

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieMobSpawnerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieMobSpawnerProcessor.java
@@ -1,7 +1,8 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon;
+import net.minecraft.resources.Identifier;
+import net.minecraft.core.registries.BuiltInRegistries;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.world.spawner.MobSpawnerData;
 
 import net.minecraft.util.Util;
@@ -15,7 +16,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -27,7 +27,7 @@ import java.util.Optional;
  */
 
 
-public class ZombieMobSpawnerProcessor extends StructureProcessor {
+public class ZombieMobSpawnerProcessor implements StructureProcessor {
     public static final ZombieMobSpawnerProcessor INSTANCE = new ZombieMobSpawnerProcessor();
     public static final MapCodec<ZombieMobSpawnerProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -35,10 +35,10 @@ public class ZombieMobSpawnerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() instanceof SpawnerBlock) {
+        if (blockInfo.state().getBlock() instanceof SpawnerBlock) {
             // Create spawner & populate with data
             MobSpawnerData spawner = MobSpawnerData.builder()
                     .spawnPotentials(WeightedList.of(new SpawnData(
@@ -46,15 +46,16 @@ public class ZombieMobSpawnerProcessor extends StructureProcessor {
                             Optional.empty(),
                             Optional.empty())))
                     .maxNearbyEntities(8)
-                    .setEntityType(EntityType.ZOMBIE)
+                    .setEntityType(BuiltInRegistries.ENTITY_TYPE.get(Identifier.fromNamespaceAndPath("minecraft", "zombie")).orElseThrow().value())
                     .build();
             CompoundTag nbt = spawner.save();
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.ZOMBIE_MOB_SPAWNER_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieRotProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieRotProcessor.java
@@ -1,14 +1,13 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
@@ -17,7 +16,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class ZombieRotProcessor extends StructureProcessor {
+public class ZombieRotProcessor implements StructureProcessor {
     public static final ZombieRotProcessor INSTANCE = new ZombieRotProcessor();
     public static final MapCodec<ZombieRotProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,18 +24,19 @@ public class ZombieRotProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE || blockInfoGlobal.state().getBlock() == Blocks.CYAN_TERRACOTTA || blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
-            if (levelReader.getBlockState(blockInfoGlobal.pos()).isAir()) {
-                blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
+        if (blockInfo.state().getBlock() == Blocks.COBBLESTONE || blockInfo.state().getBlock() == Blocks.DYED_TERRACOTTA.pick(DyeColor.CYAN) || blockInfo.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
+            if (levelReader.getBlockState(blockInfo.pos()).isAir()) {
+                blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.ZOMBIE_ROT_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieTombstoneSpawnerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieTombstoneSpawnerProcessor.java
@@ -1,7 +1,9 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon;
+import net.minecraft.resources.Identifier;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.DyeColor;
 
 import com.mojang.serialization.MapCodec;
-import com.yungnickyoung.minecraft.betterdungeons.module.StructureProcessorTypeModule;
 import com.yungnickyoung.minecraft.yungsapi.world.spawner.MobSpawnerData;
 
 import net.minecraft.util.Util;
@@ -17,7 +19,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -27,7 +28,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class ZombieTombstoneSpawnerProcessor extends StructureProcessor {
+public class ZombieTombstoneSpawnerProcessor implements StructureProcessor {
     public static final ZombieTombstoneSpawnerProcessor INSTANCE = new ZombieTombstoneSpawnerProcessor();
     public static final MapCodec<ZombieTombstoneSpawnerProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -35,25 +36,26 @@ public class ZombieTombstoneSpawnerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
-                                                             StructureTemplate.StructureBlockInfo blockInfoGlobal,
+                                                                                                                          BlockPos blockPos,
+                                                             StructureTemplate.StructureBlockInfo blockInfo,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.BLACK_STAINED_GLASS) {
+        if (blockInfo.state().getBlock() == Blocks.STAINED_GLASS.pick(DyeColor.BLACK)) {
             // Create spawner & populate with data
             MobSpawnerData spawner = MobSpawnerData.builder()
-                    .setEntityType(EntityType.SKELETON)
+                    .setEntityType(BuiltInRegistries.ENTITY_TYPE.get(Identifier.fromNamespaceAndPath("minecraft", "skeleton")).orElseThrow().value())
                     .build();
             spawner.nextSpawnData.getEntityToSpawn().put("HandItems", Util.make(new ListTag(), (handItemsTag) -> {
                 Tag ironSwordNbt = ItemStack.CODEC.encodeStart(NbtOps.INSTANCE, new ItemStack(Items.IRON_SWORD)).getOrThrow();
                 handItemsTag.add(ironSwordNbt);
             }));
             CompoundTag nbt = spawner.save();
-            blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
+            blockInfo = new StructureTemplate.StructureBlockInfo(blockInfo.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
         }
-        return blockInfoGlobal;
+        return blockInfo;
     }
 
-    protected StructureProcessorType<?> getType() {
-        return StructureProcessorTypeModule.ZOMBIE_TOMBSTONE_SPAWNER_PROCESSOR;
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonEggRoomPiece.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonEggRoomPiece.java
@@ -1,4 +1,6 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.structure.spider_dungeon.piece;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.DyeColor;
 
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
 import com.yungnickyoung.minecraft.betterdungeons.mixin.accessor.BoundingBoxAccessor;
@@ -41,7 +43,7 @@ public class SpiderDungeonEggRoomPiece extends SpiderDungeonPiece {
                                Y_MINRADIUS = 2, Y_MAXRADIUS = 3,
                                Z_MINRADIUS = 2, Z_MAXRADIUS = 3;
 
-    private static final BlockStateRandomizer WOOL_SELECTOR = BlockStateRandomizer.from(Blocks.WHITE_WOOL.defaultBlockState());
+    private static final BlockStateRandomizer WOOL_SELECTOR = BlockStateRandomizer.from(Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState());
     private static final BlockStateRandomizer COBWEB_SELECTOR = BlockStateRandomizer.from(Blocks.COBWEB.defaultBlockState());
 
     public SpiderDungeonEggRoomPiece(BlockPos startPos, int pieceChainLength) {
@@ -197,12 +199,12 @@ public class SpiderDungeonEggRoomPiece extends SpiderDungeonPiece {
         this.placeSphereRandomized(world, box, chestPos, 2, decoRand, .5f, WOOL_SELECTOR, false);
 
         // Guarantee wool immediately around chest
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX() + 1, chestPos.getY(), chestPos.getZ(), box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX() - 1, chestPos.getY(), chestPos.getZ(), box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ() + 1, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ() - 1, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX(), chestPos.getY() - 1, chestPos.getZ(), box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX(), chestPos.getY() + 1, chestPos.getZ(), box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), chestPos.getX() + 1, chestPos.getY(), chestPos.getZ(), box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), chestPos.getX() - 1, chestPos.getY(), chestPos.getZ(), box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ() + 1, box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ() - 1, box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), chestPos.getX(), chestPos.getY() - 1, chestPos.getZ(), box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), chestPos.getX(), chestPos.getY() + 1, chestPos.getZ(), box);
 
         // Surround egg with more cobweb
         this.placeSphereRandomized(world, box, chestPos.getX(), chestPos.getY(), chestPos.getZ(), 2, decoRand, .4f, COBWEB_SELECTOR, true);
@@ -216,7 +218,7 @@ public class SpiderDungeonEggRoomPiece extends SpiderDungeonPiece {
                 this.placeBlock(world, Blocks.SPAWNER.defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ(), box);
                 BlockEntity spawnerBlockEntity = world.getBlockEntity(chestPos);
                 if (spawnerBlockEntity instanceof SpawnerBlockEntity) {
-                    ((SpawnerBlockEntity) spawnerBlockEntity).setEntityId(EntityType.SPIDER, randomSource);
+                    ((SpawnerBlockEntity) spawnerBlockEntity).setEntityId(BuiltInRegistries.ENTITY_TYPE.get(Identifier.fromNamespaceAndPath("minecraft", "spider")).orElseThrow().value(), randomSource);
                 } else {
                     BetterDungeonsCommon.LOGGER.warn("Expected spider spawner entity at {}, but found none!", chestPos);
                 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonNestPiece.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonNestPiece.java
@@ -1,4 +1,7 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.structure.spider_dungeon.piece;
+import net.minecraft.resources.Identifier;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.item.DyeColor;
 
 import com.yungnickyoung.minecraft.betterdungeons.BetterDungeonsCommon;
 import com.yungnickyoung.minecraft.betterdungeons.mixin.accessor.BoundingBoxAccessor;
@@ -42,7 +45,7 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
                                Z_MINRADIUS = 6, Z_MAXRADIUS = 10;
 
     private static final BlockStateRandomizer COBWEB_SELECTOR = BlockStateRandomizer.from(Blocks.COBWEB.defaultBlockState());
-    private static final BlockStateRandomizer WOOL_SELECTOR = BlockStateRandomizer.from(Blocks.WHITE_WOOL.defaultBlockState());
+    private static final BlockStateRandomizer WOOL_SELECTOR = BlockStateRandomizer.from(Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState());
 
     public SpiderDungeonNestPiece(BlockPos startPos, int pieceChainLength) {
         super(StructurePieceTypeModule.NEST, pieceChainLength, getInitialBoundingBox(startPos));
@@ -169,7 +172,7 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
                     float radialDist = radialXDist * radialXDist + radialYDist * radialYDist + radialZDist * radialZDist;
                     if (radialDist < 1.0) {
                         if (globalX == caveStartX && globalZ == caveStartZ && globalY > caveStartY) {
-                            this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), globalX, globalY, globalZ, box);
+                            this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), globalX, globalY, globalZ, box);
                         } else if (!carvingMask.get(mask)) {
                             if (!BLOCK_BLACKLIST.contains(this.getBlock(world, globalX, globalY, globalZ, box).getBlock())) {
                                 this.placeBlock(world, Blocks.CAVE_AIR.defaultBlockState(), globalX, globalY, globalZ, box);
@@ -185,7 +188,7 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
                         float radialDistShell = radialXDistShell * radialXDistShell + radialYDistShell * radialYDistShell + radialZDistShell * radialZDistShell;
                         if (radialDistShell < 1.0) {
                             if (globalX == caveStartX && globalZ == caveStartZ && globalY > caveStartY) { // Guarantee wool up to ceiling
-                                this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), globalX, globalY, globalZ, box);
+                                this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), globalX, globalY, globalZ, box);
                             } else if (!carvingMask.get(mask)) { // Only place cobble shell on outer rim
                                 BlockState state = this.getBlock(world, globalX, globalY, globalZ, box);
 //                                if (!BLOCK_BLACKLIST.contains(state.getBlock())) { // Ignore blacklisted blocks
@@ -212,11 +215,11 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
         this.placeSphereRandomized(world, box, (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ, 2, decoRand, .5f, WOOL_SELECTOR, true);
 
         // Guarantee wool immediately around spawner
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX + 1, (int) caveStartY + 1, (int) caveStartZ, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX - 1, (int) caveStartY + 1, (int) caveStartZ, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ + 1, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ - 1, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX, (int) caveStartY, (int) caveStartZ, box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), (int) caveStartX + 1, (int) caveStartY + 1, (int) caveStartZ, box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), (int) caveStartX - 1, (int) caveStartY + 1, (int) caveStartZ, box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ + 1, box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ - 1, box);
+        this.placeBlock(world, Blocks.WOOL.pick(DyeColor.WHITE).defaultBlockState(), (int) caveStartX, (int) caveStartY, (int) caveStartZ, box);
 
         // Surround cocoon with more cobweb
         this.placeSphereRandomized(world, box, (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ, 3, decoRand, .5f, COBWEB_SELECTOR, true);
@@ -226,7 +229,7 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
         if (box.isInside(startPos)) {
             BlockEntity spawnerTileEntity = world.getBlockEntity(startPos.relative(Direction.UP));
             if (spawnerTileEntity instanceof SpawnerBlockEntity) {
-                ((SpawnerBlockEntity) spawnerTileEntity).setEntityId(EntityType.CAVE_SPIDER, randomSource);
+                ((SpawnerBlockEntity) spawnerTileEntity).setEntityId(BuiltInRegistries.ENTITY_TYPE.get(Identifier.fromNamespaceAndPath("minecraft", "cave_spider")).orElseThrow().value(), randomSource);
             } else {
                 BetterDungeonsCommon.LOGGER.warn("Expected cave spider spawner entity at {}, but found none!", startPos.relative(Direction.UP));
             }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonPiece.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonPiece.java
@@ -1,4 +1,5 @@
 package com.yungnickyoung.minecraft.betterdungeons.world.structure.spider_dungeon.piece;
+import net.minecraft.world.item.DyeColor;
 
 import com.google.common.collect.Sets;
 import com.yungnickyoung.minecraft.yungsapi.api.world.randomize.BlockStateRandomizer;
@@ -18,7 +19,7 @@ import java.util.BitSet;
 import java.util.Set;
 
 public abstract class SpiderDungeonPiece extends StructurePiece {
-    protected static final Set<Block> BLOCK_BLACKLIST = Sets.newHashSet(Blocks.DIAMOND_BLOCK, Blocks.WHITE_WOOL, Blocks.SPAWNER, Blocks.CHEST, Blocks.ACACIA_LEAVES, Blocks.BIRCH_LEAVES, Blocks.OAK_LEAVES, Blocks.DARK_OAK_LEAVES, Blocks.JUNGLE_LEAVES, Blocks.SPRUCE_LEAVES, Blocks.SHORT_GRASS, Blocks.TALL_GRASS);
+    protected static final Set<Block> BLOCK_BLACKLIST = Sets.newHashSet(Blocks.DIAMOND_BLOCK, Blocks.WOOL.pick(DyeColor.WHITE), Blocks.SPAWNER, Blocks.CHEST, Blocks.ACACIA_LEAVES, Blocks.BIRCH_LEAVES, Blocks.OAK_LEAVES, Blocks.DARK_OAK_LEAVES, Blocks.JUNGLE_LEAVES, Blocks.SPRUCE_LEAVES, Blocks.SHORT_GRASS, Blocks.TALL_GRASS);
 
     protected SpiderDungeonPiece(StructurePieceType structurePieceTypeIn, int chainLength, BoundingBox box) {
         super(structurePieceTypeIn, chainLength, box);

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,16 @@ mod_description=A complete redesign of Minecraft's dungeons!
 mod_credits=Thanks so much to all my patrons!
 license=LGPLv3
 maven_group=com.yungnickyoung.minecraft.betterdungeons
-mc_version=26.1.2
-mc_version_range=[26.1,)
-mc_version_range_fabric=>=26.1
+mc_version=26.2
+mc_version_range=[26.2,)
+mc_version_range_fabric=>=26.2
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-mc_version_neo_form=26.1.2-1
+mc_version_neo_form=26.2-2
 
 # CurseForge/Modrinth Publishing
 cursegradle_version=1.1.24
-compatible_versions=26.1.1,26.1.2
+compatible_versions=26.2
 curseforge_project_id_fabric=525586
 curseforge_project_id_neoforge=510089
 modrinth_project_id=o1C1Dkj5
@@ -30,14 +30,14 @@ debug_publish=true
 yungsapi_version=6.1.0
 
 # Fabric
-fabric_version=0.150.0
-fabric_loader_version=0.18.6
-clothconfig_version_fabric=26.1.154
-modmenu_version_fabric=18.0.0-beta.1
+fabric_version=0.156.0
+fabric_loader_version=0.19.3
+clothconfig_version_fabric=26.2.155
+modmenu_version_fabric=20.0.0
 
 # NeoForge
-neoforge_version=26.1.2.75
-neoforge_version_range=[26.1.2.75,)
+neoforge_version=26.2.0.37-beta
+neoforge_version_range=[26.2.0.37-beta,)
 neoforge_loader_version_range=[4,)
 
 # Credentials for publishing. Gets overwritten with global gradle.properties.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updates all build properties and source code to compile against Minecraft 26.2.

Changes:
- Bump `mc_version`, `fabric_version`, `fabric_loader_version`, `clothconfig`, `modmenu`, NeoForge deps
- `StructureProcessor` is now an interface (extends → implements)
- `CriterionTrigger` moved to `net.minecraft.advancements.triggers`
- Block color variants → `ColorCollection.pick(DyeColor)`
- `EntityType` static fields → `BuiltInRegistries.ENTITY_TYPE` lookups
- `EntitySpawnReason` → `EntitySpawnRequest` wrapper
- `Identifier.of` → `Identifier.fromNamespaceAndPath`
- `StructureProcessorType` no longer generic
- `markPosForPostprocessing` → `markPosForPostProcessing`

Tested: Fabric build compiles and runs on MC 26.2 server.