### PR TITLE
Port to Minecraft 26.2

### DIFF
--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/module/StructureProcessorTypeModule.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/module/StructureProcessorTypeModule.java
@@ -31,99 +31,100 @@ import com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon
 import com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon.ZombieRotProcessor;
 import com.yungnickyoung.minecraft.betterdungeons.world.processor.zombie_dungeon.ZombieTombstoneSpawnerProcessor;
 import com.yungnickyoung.minecraft.yungsapi.api.autoregister.AutoRegister;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
 
 @AutoRegister(BetterDungeonsCommon.MOD_ID)
 public class StructureProcessorTypeModule {
     @AutoRegister("mob_spawner_processor")
-    public static StructureProcessorType<MobSpawnerProcessor> MOB_SPAWNER_PROCESSOR = () -> MobSpawnerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> MOB_SPAWNER_PROCESSOR = MobSpawnerProcessor.CODEC;
 
     @AutoRegister("head_processor")
-    public static StructureProcessorType<HeadProcessor> HEAD_PROCESSOR = () -> HeadProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> HEAD_PROCESSOR = HeadProcessor.CODEC;
 
     @AutoRegister("nether_block_processor")
-    public static StructureProcessorType<NetherBlockProcessor> NETHER_BLOCK_PROCESSOR = () -> NetherBlockProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> NETHER_BLOCK_PROCESSOR = NetherBlockProcessor.CODEC;
 
     @AutoRegister("candle_processor")
-    public static StructureProcessorType<CandleProcessor> CANDLE_PROCESSOR = () -> CandleProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> CANDLE_PROCESSOR = CandleProcessor.CODEC;
 
     /* Small dungeons */
     @AutoRegister("small_dungeon_ceiling_prop_processor")
-    public static StructureProcessorType<SmallDungeonCeilingPropProcessor> SMALL_DUNGEON_CEILING_PROP_PROCESSOR = () -> SmallDungeonCeilingPropProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_CEILING_PROP_PROCESSOR = SmallDungeonCeilingPropProcessor.CODEC;
 
     @AutoRegister("small_dungeon_ceiling_lamp_processor")
-    public static StructureProcessorType<SmallDungeonCeilingLampPropProcessor> SMALL_DUNGEON_CEILING_LAMP_PROCESSOR = () -> SmallDungeonCeilingLampPropProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_CEILING_LAMP_PROCESSOR = SmallDungeonCeilingLampPropProcessor.CODEC;
 
     @AutoRegister("small_dungeon_banner_processor")
-    public static StructureProcessorType<SmallDungeonBannerProcessor> SMALL_DUNGEON_BANNER_PROCESSOR = () -> SmallDungeonBannerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_BANNER_PROCESSOR = SmallDungeonBannerProcessor.CODEC;
 
     @AutoRegister("small_dungeon_chest_processor")
-    public static StructureProcessorType<SmallDungeonChestProcessor> SMALL_DUNGEON_CHEST_PROCESSOR = () -> SmallDungeonChestProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_CHEST_PROCESSOR = SmallDungeonChestProcessor.CODEC;
 
     @AutoRegister("small_dungeon_cobblestone_processor")
-    public static StructureProcessorType<SmallDungeonCobblestoneProcessor> SMALL_DUNGEON_COBBLE_PROCESSOR = () -> SmallDungeonCobblestoneProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_COBBLE_PROCESSOR = SmallDungeonCobblestoneProcessor.CODEC;
 
     @AutoRegister("small_dungeon_leg_processor")
-    public static StructureProcessorType<SmallDungeonLegProcessor> SMALL_DUNGEON_LEG_PROCESSOR = () -> SmallDungeonLegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_LEG_PROCESSOR = SmallDungeonLegProcessor.CODEC;
 
     @AutoRegister("small_dungeon_ceiling_processor")
-    public static StructureProcessorType<SmallDungeonCeilingProcessor> SMALL_DUNGEON_CEILING_PROCESSOR = () -> SmallDungeonCeilingProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_CEILING_PROCESSOR = SmallDungeonCeilingProcessor.CODEC;
 
     @AutoRegister("small_dungeon_ore_processor")
-    public static StructureProcessorType<SmallDungeonOreProcessor> SMALL_DUNGEON_ORE_PROCESSOR = () -> SmallDungeonOreProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_DUNGEON_ORE_PROCESSOR = SmallDungeonOreProcessor.CODEC;
 
     /* Small Nether Dungeons */
     @AutoRegister("small_nether_dungeon_banner_processor")
-    public static StructureProcessorType<SmallNetherDungeonBannerProcessor> SMALL_NETHER_DUNGEON_BANNER_PROCESSOR = () -> SmallNetherDungeonBannerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_BANNER_PROCESSOR = SmallNetherDungeonBannerProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_head_processor")
-    public static StructureProcessorType<SmallNetherDungeonHeadProcessor> SMALL_NETHER_DUNGEON_HEAD_PROCESSOR = () -> SmallNetherDungeonHeadProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_HEAD_PROCESSOR = SmallNetherDungeonHeadProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_lava_block_processor")
-    public static StructureProcessorType<SmallNetherDungeonLavaBlockProcessor> SMALL_NETHER_DUNGEON_LAVA_BLOCK_PROCESSOR = () -> SmallNetherDungeonLavaBlockProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_LAVA_BLOCK_PROCESSOR = SmallNetherDungeonLavaBlockProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_entrance_stairs_processor")
-    public static StructureProcessorType<SmallNetherDungeonEntranceStairsProcessor> SMALL_NETHER_DUNGEON_ENTRANCE_STAIRS_PROCESSOR = () -> SmallNetherDungeonEntranceStairsProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_ENTRANCE_STAIRS_PROCESSOR = SmallNetherDungeonEntranceStairsProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_leg_processor")
-    public static StructureProcessorType<SmallNetherDungeonLegProcessor> SMALL_NETHER_DUNGEON_LEG_PROCESSOR = () -> SmallNetherDungeonLegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_LEG_PROCESSOR = SmallNetherDungeonLegProcessor.CODEC;
 
     @AutoRegister("small_nether_dungeon_mob_spawner_processor")
-    public static StructureProcessorType<SmallNetherDungeonMobSpawner> SMALL_NETHER_DUNGEON_MOB_SPAWNER_PROCESSOR = () -> SmallNetherDungeonMobSpawner.CODEC;
+    public static MapCodec<? extends StructureProcessor> SMALL_NETHER_DUNGEON_MOB_SPAWNER_PROCESSOR = SmallNetherDungeonMobSpawner.CODEC;
 
     /* Skeleton dungeons */
     @AutoRegister("skeleton_dungeon_ruined_stone_bricks_processor")
-    public static StructureProcessorType<RuinedStoneBrickProcessor> SKELETON_DUNGEON_RUINED_STONE_BRICKS_PROCESSOR = () -> RuinedStoneBrickProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SKELETON_DUNGEON_RUINED_STONE_BRICKS_PROCESSOR = RuinedStoneBrickProcessor.CODEC;
 
     @AutoRegister("skeleton_mob_spawner_processor")
-    public static StructureProcessorType<SkeletonMobSpawnerProcessor> SKELETON_MOB_SPAWNER_PROCESSOR = () -> SkeletonMobSpawnerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SKELETON_MOB_SPAWNER_PROCESSOR = SkeletonMobSpawnerProcessor.CODEC;
 
     @AutoRegister("skeleton_dungeon_leg_processor")
-    public static StructureProcessorType<SkeletonDungeonLegProcessor> SKELETON_DUNGEON_LEG_PROCESSOR = () -> SkeletonDungeonLegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> SKELETON_DUNGEON_LEG_PROCESSOR = SkeletonDungeonLegProcessor.CODEC;
 
     /* Zombie dungeons */
 
     @AutoRegister("zombie_dungeon_cubby_processor")
-    public static StructureProcessorType<ZombieDungeonCubbyProcessor> ZOMBIE_DUNGEON_CUBBY_PROCESSOR = () -> ZombieDungeonCubbyProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_DUNGEON_CUBBY_PROCESSOR = ZombieDungeonCubbyProcessor.CODEC;
 
     @AutoRegister("zombie_dungeon_stair_processor")
-    public static StructureProcessorType<ZombieDungeonStairProcessor> ZOMBIE_DUNGEON_STAIR_PROCESSOR = () -> ZombieDungeonStairProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_DUNGEON_STAIR_PROCESSOR = ZombieDungeonStairProcessor.CODEC;
 
     @AutoRegister("zombie_mob_spawner_processor")
-    public static StructureProcessorType<ZombieMobSpawnerProcessor> ZOMBIE_MOB_SPAWNER_PROCESSOR = () -> ZombieMobSpawnerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_MOB_SPAWNER_PROCESSOR = ZombieMobSpawnerProcessor.CODEC;
 
     @AutoRegister("zombie_tombstone_spawner_processor")
-    public static StructureProcessorType<ZombieTombstoneSpawnerProcessor> ZOMBIE_TOMBSTONE_SPAWNER_PROCESSOR = () -> ZombieTombstoneSpawnerProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_TOMBSTONE_SPAWNER_PROCESSOR = ZombieTombstoneSpawnerProcessor.CODEC;
 
     @AutoRegister("zombie_main_stairs_processor")
-    public static StructureProcessorType<ZombieMainStairsProcessor> ZOMBIE_MAIN_STAIRS_PROCESSOR = () -> ZombieMainStairsProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_MAIN_STAIRS_PROCESSOR = ZombieMainStairsProcessor.CODEC;
 
     @AutoRegister("zombie_rot_processor")
-    public static StructureProcessorType<ZombieRotProcessor> ZOMBIE_ROT_PROCESSOR = () -> ZombieRotProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_ROT_PROCESSOR = ZombieRotProcessor.CODEC;
 
     @AutoRegister("zombie_dungeon_leg_processor")
-    public static StructureProcessorType<ZombieDungeonLegProcessor> ZOMBIE_DUNGEON_LEG_PROCESSOR = () -> ZombieDungeonLegProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_DUNGEON_LEG_PROCESSOR = ZombieDungeonLegProcessor.CODEC;
 
     @AutoRegister("zombie_dungeon_flower_pot_processor")
-    public static StructureProcessorType<ZombieDungeonFlowerPotProcessor> ZOMBIE_DUNGEON_FLOWER_POT_PROCESSOR = () -> ZombieDungeonFlowerPotProcessor.CODEC;
+    public static MapCodec<? extends StructureProcessor> ZOMBIE_DUNGEON_FLOWER_POT_PROCESSOR = ZombieDungeonFlowerPotProcessor.CODEC;
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/CandleProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/CandleProcessor.java
@@ -13,7 +13,6 @@ import net.minecraft.world.level.block.SeaPickleBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -21,18 +20,18 @@ import java.util.List;
 
 
 
-public class CandleProcessor extends StructureProcessor {
+public class CandleProcessor implements StructureProcessor {
     public static final CandleProcessor INSTANCE = new CandleProcessor();
     public static final MapCodec<CandleProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
-    private static final List<Block> CANDLES = List.of(Blocks.CANDLE, Blocks.WHITE_CANDLE, Blocks.GRAY_CANDLE,
-            Blocks.LIGHT_GRAY_CANDLE, Blocks.BROWN_CANDLE, Blocks.GREEN_CANDLE, Blocks.PURPLE_CANDLE, Blocks.BLACK_CANDLE);
+    private static final List<Block> CANDLES = List.of(Blocks.CANDLE, Blocks.DYED_CANDLE.white(), Blocks.DYED_CANDLE.gray(),
+            Blocks.DYED_CANDLE.lightGray(), Blocks.DYED_CANDLE.brown(), Blocks.DYED_CANDLE.green(), Blocks.DYED_CANDLE.purple(), Blocks.DYED_CANDLE.black());
 
     @Override
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof SeaPickleBlock) {
@@ -52,7 +51,7 @@ public class CandleProcessor extends StructureProcessor {
         return CANDLES.get(i);
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.CANDLE_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/HeadProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/HeadProcessor.java
@@ -9,14 +9,13 @@ import net.minecraft.world.level.block.AbstractSkullBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class HeadProcessor extends StructureProcessor {
+public class HeadProcessor implements StructureProcessor {
     public static final HeadProcessor INSTANCE = new HeadProcessor();
     public static final MapCodec<HeadProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -24,7 +23,7 @@ public class HeadProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof AbstractSkullBlock) {
@@ -35,7 +34,7 @@ public class HeadProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.HEAD_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/MobSpawnerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/MobSpawnerProcessor.java
@@ -17,7 +17,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -28,7 +27,7 @@ import java.util.Optional;
  */
 
 
-public class MobSpawnerProcessor extends StructureProcessor {
+public class MobSpawnerProcessor implements StructureProcessor {
     public static final MapCodec<MobSpawnerProcessor> CODEC = RecordCodecBuilder.mapCodec(codecBuilder -> codecBuilder
             .group(
                     Identifier.CODEC
@@ -50,7 +49,7 @@ public class MobSpawnerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof SpawnerBlock) {
@@ -74,7 +73,7 @@ public class MobSpawnerProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.MOB_SPAWNER_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/NetherBlockProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/NetherBlockProcessor.java
@@ -10,14 +10,13 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.LanternBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class NetherBlockProcessor extends StructureProcessor {
+public class NetherBlockProcessor implements StructureProcessor {
     public static final NetherBlockProcessor INSTANCE = new NetherBlockProcessor();
     public static final MapCodec<NetherBlockProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,7 +24,7 @@ public class NetherBlockProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (!BetterDungeonsCommon.CONFIG.general.enableNetherBlocks) {
@@ -40,7 +39,7 @@ public class NetherBlockProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.NETHER_BLOCK_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/RuinedStoneBrickProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/RuinedStoneBrickProcessor.java
@@ -11,7 +11,6 @@ import net.minecraft.world.level.block.SlabBlock;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -23,7 +22,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class RuinedStoneBrickProcessor extends StructureProcessor {
+public class RuinedStoneBrickProcessor implements StructureProcessor {
     public static final RuinedStoneBrickProcessor INSTANCE = new RuinedStoneBrickProcessor();
     public static final MapCodec<RuinedStoneBrickProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -38,10 +37,10 @@ public class RuinedStoneBrickProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.YELLOW_STAINED_GLASS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.STAINED_GLASS.yellow()) {
             if (levelReader.getBlockState(blockInfoGlobal.pos()).isAir()) {
                 blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             } else {
@@ -57,7 +56,7 @@ public class RuinedStoneBrickProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SKELETON_DUNGEON_RUINED_STONE_BRICKS_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/SkeletonDungeonLegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/SkeletonDungeonLegProcessor.java
@@ -14,7 +14,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -25,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class SkeletonDungeonLegProcessor extends StructureProcessor {
+public class SkeletonDungeonLegProcessor implements StructureProcessor {
     public static final SkeletonDungeonLegProcessor INSTANCE = new SkeletonDungeonLegProcessor();
     public static final MapCodec<SkeletonDungeonLegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -36,10 +35,10 @@ public class SkeletonDungeonLegProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.BLUE_STAINED_GLASS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.STAINED_GLASS.blue()) {
             if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
                 return blockInfoGlobal;
             }
@@ -62,7 +61,7 @@ public class SkeletonDungeonLegProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SKELETON_DUNGEON_LEG_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/SkeletonMobSpawnerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/skeleton_dungeon/SkeletonMobSpawnerProcessor.java
@@ -15,7 +15,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -27,7 +26,7 @@ import java.util.Optional;
  */
 
 
-public class SkeletonMobSpawnerProcessor extends StructureProcessor {
+public class SkeletonMobSpawnerProcessor implements StructureProcessor {
     public static final SkeletonMobSpawnerProcessor INSTANCE = new SkeletonMobSpawnerProcessor();
     public static final MapCodec<SkeletonMobSpawnerProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -35,7 +34,7 @@ public class SkeletonMobSpawnerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof SpawnerBlock) {
@@ -48,7 +47,7 @@ public class SkeletonMobSpawnerProcessor extends StructureProcessor {
                     .requiredPlayerRange(18)
                     .maxNearbyEntities(8)
                     .maxSpawnDelay(650)
-                    .setEntityType(EntityType.SKELETON)
+                    .setEntityType(net.minecraft.world.entity.EntityTypes.SKELETON)
                     .build();
             CompoundTag nbt = spawner.save();
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
@@ -56,7 +55,7 @@ public class SkeletonMobSpawnerProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SKELETON_MOB_SPAWNER_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonBannerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonBannerProcessor.java
@@ -22,7 +22,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import java.util.Objects;
@@ -34,7 +33,7 @@ import java.util.Objects;
  */
 
 
-public class SmallDungeonBannerProcessor extends StructureProcessor {
+public class SmallDungeonBannerProcessor implements StructureProcessor {
     public static final MapCodec<SmallDungeonBannerProcessor> CODEC = RecordCodecBuilder.mapCodec(codecBuilder -> codecBuilder
             .group(
                     Codec.STRING
@@ -54,7 +53,7 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
 
     // All banners
     public static final Banner SMALL_DUNGEON_SKELETON_BANNER = new Banner.Builder()
-            .blockState(Blocks.BLACK_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.black().defaultBlockState())
             .pattern(BannerPatterns.CURLY_BORDER, DyeColor.WHITE)
             .pattern(BannerPatterns.STRIPE_CENTER, DyeColor.WHITE)
             .pattern(BannerPatterns.STRIPE_BOTTOM, DyeColor.BLACK)
@@ -66,7 +65,7 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner SMALL_DUNGEON_ZOMBIE_BANNER = new Banner.Builder()
-            .blockState(Blocks.RED_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.red().defaultBlockState())
             .pattern(BannerPatterns.TRIANGLE_BOTTOM, DyeColor.PINK)
             .pattern(BannerPatterns.CIRCLE_MIDDLE, DyeColor.GRAY)
             .pattern(BannerPatterns.GRADIENT, DyeColor.BLACK)
@@ -78,7 +77,7 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner SMALL_DUNGEON_SPIDER_BANNER = new Banner.Builder()
-            .blockState(Blocks.RED_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.red().defaultBlockState())
             .pattern(BannerPatterns.FLOWER, DyeColor.GRAY)
             .pattern(BannerPatterns.BORDER, DyeColor.GRAY)
             .pattern(BannerPatterns.STRAIGHT_CROSS, DyeColor.GRAY)
@@ -93,13 +92,13 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof AbstractBannerBlock) {
             // Make sure we only operate on the placeholder banners
             var globalNbt = Objects.requireNonNullElseGet(blockInfoGlobal.nbt(), CompoundTag::new);
-            if (blockInfoGlobal.state().getBlock() == Blocks.RED_WALL_BANNER &&
+            if (blockInfoGlobal.state().getBlock() == Blocks.WALL_BANNER.red() &&
                 globalNbt.getList("patterns").filter(l -> !l.isEmpty()).isEmpty()) {
                 // Fetch thread-local dungeon context
                 DungeonContext context = DungeonContext.peek();
@@ -126,7 +125,7 @@ public class SmallDungeonBannerProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_DUNGEON_BANNER_PROCESSOR;
     }
 

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingLampPropProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingLampPropProcessor.java
@@ -9,12 +9,11 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
 
-public class SmallDungeonCeilingLampPropProcessor extends StructureProcessor {
+public class SmallDungeonCeilingLampPropProcessor implements StructureProcessor {
     public static final SmallDungeonCeilingLampPropProcessor INSTANCE = new SmallDungeonCeilingLampPropProcessor();
     public static final MapCodec<SmallDungeonCeilingLampPropProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -22,10 +21,10 @@ public class SmallDungeonCeilingLampPropProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.CYAN_STAINED_GLASS)) {
+        if (blockInfoGlobal.state().is(Blocks.STAINED_GLASS.cyan())) {
             RandomSource random = structurePlacementData.getRandom(blockInfoGlobal.pos());
 
             // Choose lamp prop
@@ -40,7 +39,7 @@ public class SmallDungeonCeilingLampPropProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_DUNGEON_CEILING_LAMP_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingProcessor.java
@@ -9,7 +9,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
@@ -18,7 +17,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class SmallDungeonCeilingProcessor extends StructureProcessor {
+public class SmallDungeonCeilingProcessor implements StructureProcessor {
     public static final SmallDungeonCeilingProcessor INSTANCE = new SmallDungeonCeilingProcessor();
     public static final MapCodec<SmallDungeonCeilingProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -26,10 +25,10 @@ public class SmallDungeonCeilingProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.ORANGE_STAINED_GLASS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.STAINED_GLASS.orange()) {
             if (levelReader.getFluidState(blockInfoGlobal.pos()).is(FluidTags.WATER) || levelReader.getFluidState(blockInfoGlobal.pos()).is(FluidTags.LAVA)) {
                 blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.COBBLESTONE.defaultBlockState(), null);
             } else {
@@ -39,7 +38,7 @@ public class SmallDungeonCeilingProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_DUNGEON_CEILING_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingPropProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCeilingPropProcessor.java
@@ -10,12 +10,11 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 
 
-public class SmallDungeonCeilingPropProcessor extends StructureProcessor {
+public class SmallDungeonCeilingPropProcessor implements StructureProcessor {
     public static final SmallDungeonCeilingPropProcessor INSTANCE = new SmallDungeonCeilingPropProcessor();
     public static final MapCodec<SmallDungeonCeilingPropProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -23,10 +22,10 @@ public class SmallDungeonCeilingPropProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.MAGENTA_STAINED_GLASS)) {
+        if (blockInfoGlobal.state().is(Blocks.STAINED_GLASS.magenta())) {
             // If ceiling isn't solid, place air since we don't want floating props
             if (!levelReader.getBlockState(blockInfoGlobal.pos().above()).isFaceSturdy(levelReader, blockInfoGlobal.pos().above(), Direction.DOWN)) {
                 return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
@@ -38,7 +37,7 @@ public class SmallDungeonCeilingPropProcessor extends StructureProcessor {
             // Choose ceiling prop
             if (f < .2f) blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.IRON_CHAIN.defaultBlockState(), blockInfoGlobal.nbt());
             else blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), blockInfoGlobal.nbt());
-        } else if (blockInfoGlobal.state().is(Blocks.BROWN_STAINED_GLASS)) {
+        } else if (blockInfoGlobal.state().is(Blocks.STAINED_GLASS.brown())) {
             // If ceiling isn't solid, simply ignore processing since we don't want floating props
             if (!levelReader.getBlockState(blockInfoGlobal.pos().above(2)).isFaceSturdy(levelReader, blockInfoGlobal.pos().above(), Direction.DOWN)) {
                 return new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
@@ -60,7 +59,7 @@ public class SmallDungeonCeilingPropProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_DUNGEON_CEILING_PROP_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonChestProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonChestProcessor.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ChestBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
@@ -20,7 +19,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class SmallDungeonChestProcessor extends StructureProcessor {
+public class SmallDungeonChestProcessor implements StructureProcessor {
     public static final SmallDungeonChestProcessor INSTANCE = new SmallDungeonChestProcessor();
     public static final MapCodec<SmallDungeonChestProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -28,7 +27,7 @@ public class SmallDungeonChestProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof ChestBlock) {
@@ -51,7 +50,7 @@ public class SmallDungeonChestProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_DUNGEON_CHEST_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCobblestoneProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonCobblestoneProcessor.java
@@ -8,7 +8,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
@@ -17,7 +16,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class SmallDungeonCobblestoneProcessor extends StructureProcessor {
+public class SmallDungeonCobblestoneProcessor implements StructureProcessor {
     public static final SmallDungeonCobblestoneProcessor INSTANCE = new SmallDungeonCobblestoneProcessor();
     public static final MapCodec<SmallDungeonCobblestoneProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,7 +24,7 @@ public class SmallDungeonCobblestoneProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE) {
@@ -36,7 +35,7 @@ public class SmallDungeonCobblestoneProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_DUNGEON_COBBLE_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonLegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonLegProcessor.java
@@ -14,7 +14,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -25,7 +24,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class SmallDungeonLegProcessor extends StructureProcessor {
+public class SmallDungeonLegProcessor implements StructureProcessor {
     public static final SmallDungeonLegProcessor INSTANCE = new SmallDungeonLegProcessor();
     public static final MapCodec<SmallDungeonLegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -37,10 +36,10 @@ public class SmallDungeonLegProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.YELLOW_STAINED_GLASS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.STAINED_GLASS.yellow()) {
             if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
                 return blockInfoGlobal;
             }
@@ -63,7 +62,7 @@ public class SmallDungeonLegProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_DUNGEON_LEG_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonOreProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_dungeon/SmallDungeonOreProcessor.java
@@ -11,7 +11,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import java.util.function.Predicate;
@@ -21,25 +20,30 @@ import java.util.function.Predicate;
  */
 
 
-public class SmallDungeonOreProcessor extends StructureProcessor {
+public class SmallDungeonOreProcessor implements StructureProcessor {
     public static final SmallDungeonOreProcessor INSTANCE = new SmallDungeonOreProcessor();
     public static final MapCodec<SmallDungeonOreProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
     private static final Predicate<BlockState> isOre = blockState ->
             blockState.is(BlockTags.GOLD_ORES) ||
             blockState.is(BlockTags.IRON_ORES) ||
-            blockState.is(BlockTags.DIAMOND_ORES) ||
-            blockState.is(BlockTags.REDSTONE_ORES) ||
-            blockState.is(BlockTags.LAPIS_ORES) ||
-            blockState.is(BlockTags.COAL_ORES) ||
-            blockState.is(BlockTags.EMERALD_ORES) ||
+            blockState.is(Blocks.DIAMOND_ORE) ||
+            blockState.is(Blocks.DEEPSLATE_DIAMOND_ORE) ||
+            blockState.is(Blocks.REDSTONE_ORE) ||
+            blockState.is(Blocks.DEEPSLATE_REDSTONE_ORE) ||
+            blockState.is(Blocks.LAPIS_ORE) ||
+            blockState.is(Blocks.DEEPSLATE_LAPIS_ORE) ||
+            blockState.is(Blocks.COAL_ORE) ||
+            blockState.is(Blocks.DEEPSLATE_COAL_ORE) ||
+            blockState.is(Blocks.EMERALD_ORE) ||
+            blockState.is(Blocks.DEEPSLATE_EMERALD_ORE) ||
             blockState.is(BlockTags.COPPER_ORES);
 
     @Override
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (isOre.test(blockInfoGlobal.state())) {
@@ -50,7 +54,7 @@ public class SmallDungeonOreProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_DUNGEON_ORE_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonBannerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonBannerProcessor.java
@@ -22,7 +22,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -35,7 +34,7 @@ import java.util.Objects;
  */
 
 
-public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
+public class SmallNetherDungeonBannerProcessor implements StructureProcessor {
     public static final MapCodec<SmallNetherDungeonBannerProcessor> CODEC = RecordCodecBuilder.mapCodec(codecBuilder -> codecBuilder
             .group(
                     Codec.STRING
@@ -55,7 +54,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
 
     // All banners
     public static final Banner SKELETON_BANNER = new Banner.Builder()
-            .blockState(Blocks.BLACK_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.black().defaultBlockState())
             .pattern(BannerPatterns.CURLY_BORDER, DyeColor.WHITE)
             .pattern(BannerPatterns.STRIPE_CENTER, DyeColor.WHITE)
             .pattern(BannerPatterns.STRIPE_BOTTOM, DyeColor.BLACK)
@@ -67,7 +66,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner WITHER_SKELETON_BANNER = new Banner.Builder()
-            .blockState(Blocks.RED_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.red().defaultBlockState())
             .pattern(BannerPatterns.CURLY_BORDER, DyeColor.BLACK)
             .pattern(BannerPatterns.STRIPE_CENTER, DyeColor.BLACK)
             .pattern(BannerPatterns.STRIPE_BOTTOM, DyeColor.RED)
@@ -79,7 +78,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner ZOMBIFIED_PIGLIN_BANNER = new Banner.Builder()
-            .blockState(Blocks.PINK_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.pink().defaultBlockState())
             .pattern(BannerPatterns.STRIPE_LEFT, DyeColor.GREEN)
             .pattern(BannerPatterns.TRIANGLES_TOP, DyeColor.BLACK)
             .pattern(BannerPatterns.TRIANGLES_TOP, DyeColor.PINK)
@@ -97,7 +96,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
             .build();
 
     public static final Banner BLAZE_BANNER = new Banner.Builder()
-            .blockState(Blocks.RED_WALL_BANNER.defaultBlockState())
+            .blockState(Blocks.WALL_BANNER.red().defaultBlockState())
             .pattern(BannerPatterns.STRIPE_SMALL, DyeColor.YELLOW)
             .pattern(BannerPatterns.TRIANGLE_TOP, DyeColor.RED)
             .pattern(BannerPatterns.TRIANGLE_TOP, DyeColor.RED)
@@ -113,13 +112,13 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof AbstractBannerBlock) {
             // Make sure we only operate on the placeholder banners
             var globalNbt = Objects.requireNonNullElseGet(blockInfoGlobal.nbt(), CompoundTag::new);
-            if (blockInfoGlobal.state().getBlock() == Blocks.GRAY_WALL_BANNER &&
+            if (blockInfoGlobal.state().getBlock() == Blocks.WALL_BANNER.gray() &&
                 globalNbt.getList("patterns").filter(l -> !l.isEmpty()).isEmpty()) {
                 // Fetch thread-local dungeon context
                 DungeonContext context = DungeonContext.peek();
@@ -146,7 +145,7 @@ public class SmallNetherDungeonBannerProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_BANNER_PROCESSOR;
     }
 

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonEntranceStairsProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonEntranceStairsProcessor.java
@@ -12,14 +12,13 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.StairBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class SmallNetherDungeonEntranceStairsProcessor extends StructureProcessor {
+public class SmallNetherDungeonEntranceStairsProcessor implements StructureProcessor {
     public static final SmallNetherDungeonEntranceStairsProcessor INSTANCE = new SmallNetherDungeonEntranceStairsProcessor();
     public static final MapCodec<SmallNetherDungeonEntranceStairsProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -27,7 +26,7 @@ public class SmallNetherDungeonEntranceStairsProcessor extends StructureProcesso
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().is(Blocks.BRICK_STAIRS)) {
@@ -47,7 +46,7 @@ public class SmallNetherDungeonEntranceStairsProcessor extends StructureProcesso
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_ENTRANCE_STAIRS_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonHeadProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonHeadProcessor.java
@@ -10,14 +10,13 @@ import net.minecraft.world.level.block.AbstractSkullBlock;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class SmallNetherDungeonHeadProcessor extends StructureProcessor {
+public class SmallNetherDungeonHeadProcessor implements StructureProcessor {
     public static final SmallNetherDungeonHeadProcessor INSTANCE = new SmallNetherDungeonHeadProcessor();
     public static final MapCodec<SmallNetherDungeonHeadProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,7 +24,7 @@ public class SmallNetherDungeonHeadProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof AbstractSkullBlock) {
@@ -36,7 +35,7 @@ public class SmallNetherDungeonHeadProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_HEAD_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonLavaBlockProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonLavaBlockProcessor.java
@@ -10,14 +10,13 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class SmallNetherDungeonLavaBlockProcessor extends StructureProcessor {
+public class SmallNetherDungeonLavaBlockProcessor implements StructureProcessor {
     public static final SmallNetherDungeonLavaBlockProcessor INSTANCE = new SmallNetherDungeonLavaBlockProcessor();
     public static final MapCodec<SmallNetherDungeonLavaBlockProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,20 +24,20 @@ public class SmallNetherDungeonLavaBlockProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().is(Blocks.ORANGE_WOOL)) {
+        if (blockInfoGlobal.state().is(Blocks.WOOL.orange())) {
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.LAVA.defaultBlockState(), null);
             if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
                 return blockInfoGlobal;
             }
-            levelReader.getChunk(blockInfoGlobal.pos()).markPosForPostprocessing(blockInfoGlobal.pos()); // Schedule fluid tick
+            levelReader.getChunk(blockInfoGlobal.pos()).markPosForPostProcessing(blockInfoGlobal.pos()); // Schedule fluid tick
         }
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_LAVA_BLOCK_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonLegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonLegProcessor.java
@@ -12,7 +12,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -23,7 +22,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class SmallNetherDungeonLegProcessor extends StructureProcessor {
+public class SmallNetherDungeonLegProcessor implements StructureProcessor {
     public static final SmallNetherDungeonLegProcessor INSTANCE = new SmallNetherDungeonLegProcessor();
     public static final MapCodec<SmallNetherDungeonLegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -31,10 +30,10 @@ public class SmallNetherDungeonLegProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.ORANGE_TERRACOTTA) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.DYED_TERRACOTTA.orange()) {
             if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
                 return blockInfoGlobal;
             }
@@ -55,7 +54,7 @@ public class SmallNetherDungeonLegProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_LEG_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonMobSpawner.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/small_nether_dungeon/SmallNetherDungeonMobSpawner.java
@@ -24,7 +24,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -32,7 +31,7 @@ import java.util.Optional;
 
 
 
-public class SmallNetherDungeonMobSpawner extends StructureProcessor {
+public class SmallNetherDungeonMobSpawner implements StructureProcessor {
     public static final MapCodec<SmallNetherDungeonMobSpawner> CODEC = RecordCodecBuilder.mapCodec(codecBuilder -> codecBuilder
             .group(
                     Identifier.CODEC
@@ -54,7 +53,7 @@ public class SmallNetherDungeonMobSpawner extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof SpawnerBlock) {
@@ -152,7 +151,7 @@ public class SmallNetherDungeonMobSpawner extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.SMALL_NETHER_DUNGEON_MOB_SPAWNER_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonCubbyProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonCubbyProcessor.java
@@ -14,7 +14,6 @@ import net.minecraft.world.level.block.state.properties.Half;
 import net.minecraft.world.level.block.state.properties.SlabType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -24,7 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class ZombieDungeonCubbyProcessor extends StructureProcessor {
+public class ZombieDungeonCubbyProcessor implements StructureProcessor {
     public static final ZombieDungeonCubbyProcessor INSTANCE = new ZombieDungeonCubbyProcessor();
     public static final MapCodec<ZombieDungeonCubbyProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -37,7 +36,7 @@ public class ZombieDungeonCubbyProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
@@ -58,7 +57,7 @@ public class ZombieDungeonCubbyProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.ZOMBIE_DUNGEON_CUBBY_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonFlowerPotProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonFlowerPotProcessor.java
@@ -10,14 +10,13 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
 
 
-public class ZombieDungeonFlowerPotProcessor extends StructureProcessor {
+public class ZombieDungeonFlowerPotProcessor implements StructureProcessor {
     public static final ZombieDungeonFlowerPotProcessor INSTANCE = new ZombieDungeonFlowerPotProcessor();
     public static final MapCodec<ZombieDungeonFlowerPotProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -33,7 +32,7 @@ public class ZombieDungeonFlowerPotProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().is(Blocks.POTTED_CORNFLOWER)) {
@@ -44,7 +43,7 @@ public class ZombieDungeonFlowerPotProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.ZOMBIE_DUNGEON_FLOWER_POT_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonLegProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonLegProcessor.java
@@ -15,7 +15,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -28,7 +27,7 @@ import java.util.Optional;
  */
 
 
-public class ZombieDungeonLegProcessor extends StructureProcessor implements ISafeWorldModifier {
+public class ZombieDungeonLegProcessor implements StructureProcessor, ISafeWorldModifier {
     public static final ZombieDungeonLegProcessor INSTANCE = new ZombieDungeonLegProcessor();
     public static final MapCodec<ZombieDungeonLegProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -39,10 +38,10 @@ public class ZombieDungeonLegProcessor extends StructureProcessor implements ISa
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.MAGENTA_STAINED_GLASS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.STAINED_GLASS.magenta()) {
             if (levelReader instanceof WorldGenRegion worldGenRegion && !worldGenRegion.getCenter().equals(ChunkPos.containing(blockInfoGlobal.pos()))) {
                 return blockInfoGlobal;
             }
@@ -80,7 +79,7 @@ public class ZombieDungeonLegProcessor extends StructureProcessor implements ISa
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.ZOMBIE_DUNGEON_LEG_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonStairProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieDungeonStairProcessor.java
@@ -11,7 +11,6 @@ import net.minecraft.world.level.block.StairBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -21,7 +20,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class ZombieDungeonStairProcessor extends StructureProcessor {
+public class ZombieDungeonStairProcessor implements StructureProcessor {
     public static final ZombieDungeonStairProcessor INSTANCE = new ZombieDungeonStairProcessor();
     public static final MapCodec<ZombieDungeonStairProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -37,7 +36,7 @@ public class ZombieDungeonStairProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
@@ -58,7 +57,7 @@ public class ZombieDungeonStairProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.ZOMBIE_DUNGEON_STAIR_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieMainStairsProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieMainStairsProcessor.java
@@ -19,7 +19,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -30,7 +29,7 @@ import java.util.Optional;
  */
 
 
-public class ZombieMainStairsProcessor extends StructureProcessor implements ISafeWorldModifier {
+public class ZombieMainStairsProcessor implements StructureProcessor, ISafeWorldModifier {
     public static final ZombieMainStairsProcessor INSTANCE = new ZombieMainStairsProcessor();
     public static final MapCodec<ZombieMainStairsProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -49,7 +48,7 @@ public class ZombieMainStairsProcessor extends StructureProcessor implements ISa
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() == Blocks.WARPED_STAIRS) { // Warped stairs are the marker for the main staircase
@@ -297,7 +296,7 @@ public class ZombieMainStairsProcessor extends StructureProcessor implements ISa
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.ZOMBIE_MAIN_STAIRS_PROCESSOR;
     }
 

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieMobSpawnerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieMobSpawnerProcessor.java
@@ -15,7 +15,6 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -27,7 +26,7 @@ import java.util.Optional;
  */
 
 
-public class ZombieMobSpawnerProcessor extends StructureProcessor {
+public class ZombieMobSpawnerProcessor implements StructureProcessor {
     public static final ZombieMobSpawnerProcessor INSTANCE = new ZombieMobSpawnerProcessor();
     public static final MapCodec<ZombieMobSpawnerProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -35,7 +34,7 @@ public class ZombieMobSpawnerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
         if (blockInfoGlobal.state().getBlock() instanceof SpawnerBlock) {
@@ -46,7 +45,7 @@ public class ZombieMobSpawnerProcessor extends StructureProcessor {
                             Optional.empty(),
                             Optional.empty())))
                     .maxNearbyEntities(8)
-                    .setEntityType(EntityType.ZOMBIE)
+                    .setEntityType(net.minecraft.world.entity.EntityTypes.ZOMBIE)
                     .build();
             CompoundTag nbt = spawner.save();
             blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.SPAWNER.defaultBlockState(), nbt);
@@ -54,7 +53,7 @@ public class ZombieMobSpawnerProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.ZOMBIE_MOB_SPAWNER_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieRotProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieRotProcessor.java
@@ -8,7 +8,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 /**
@@ -17,7 +16,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
  */
 
 
-public class ZombieRotProcessor extends StructureProcessor {
+public class ZombieRotProcessor implements StructureProcessor {
     public static final ZombieRotProcessor INSTANCE = new ZombieRotProcessor();
     public static final MapCodec<ZombieRotProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -25,10 +24,10 @@ public class ZombieRotProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE || blockInfoGlobal.state().getBlock() == Blocks.CYAN_TERRACOTTA || blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE || blockInfoGlobal.state().getBlock() == Blocks.DYED_TERRACOTTA.cyan() || blockInfoGlobal.state().getBlock() == Blocks.COBBLESTONE_STAIRS) {
             if (levelReader.getBlockState(blockInfoGlobal.pos()).isAir()) {
                 blockInfoGlobal = new StructureTemplate.StructureBlockInfo(blockInfoGlobal.pos(), Blocks.CAVE_AIR.defaultBlockState(), null);
             }
@@ -36,7 +35,7 @@ public class ZombieRotProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.ZOMBIE_ROT_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieTombstoneSpawnerProcessor.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/processor/zombie_dungeon/ZombieTombstoneSpawnerProcessor.java
@@ -17,7 +17,6 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
-import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -27,7 +26,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  */
 
 
-public class ZombieTombstoneSpawnerProcessor extends StructureProcessor {
+public class ZombieTombstoneSpawnerProcessor implements StructureProcessor {
     public static final ZombieTombstoneSpawnerProcessor INSTANCE = new ZombieTombstoneSpawnerProcessor();
     public static final MapCodec<ZombieTombstoneSpawnerProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
 
@@ -35,13 +34,13 @@ public class ZombieTombstoneSpawnerProcessor extends StructureProcessor {
     public StructureTemplate.StructureBlockInfo processBlock(LevelReader levelReader,
                                                              BlockPos jigsawPiecePos,
                                                              BlockPos jigsawPieceBottomCenterPos,
-                                                             StructureTemplate.StructureBlockInfo blockInfoLocal,
+                                                             BlockPos templateRelativePos,
                                                              StructureTemplate.StructureBlockInfo blockInfoGlobal,
                                                              StructurePlaceSettings structurePlacementData) {
-        if (blockInfoGlobal.state().getBlock() == Blocks.BLACK_STAINED_GLASS) {
+        if (blockInfoGlobal.state().getBlock() == Blocks.STAINED_GLASS.black()) {
             // Create spawner & populate with data
             MobSpawnerData spawner = MobSpawnerData.builder()
-                    .setEntityType(EntityType.SKELETON)
+                    .setEntityType(net.minecraft.world.entity.EntityTypes.SKELETON)
                     .build();
             spawner.nextSpawnData.getEntityToSpawn().put("HandItems", Util.make(new ListTag(), (handItemsTag) -> {
                 Tag ironSwordNbt = ItemStack.CODEC.encodeStart(NbtOps.INSTANCE, new ItemStack(Items.IRON_SWORD)).getOrThrow();
@@ -53,7 +52,7 @@ public class ZombieTombstoneSpawnerProcessor extends StructureProcessor {
         return blockInfoGlobal;
     }
 
-    protected StructureProcessorType<?> getType() {
+    public MapCodec<? extends StructureProcessor> codec() {
         return StructureProcessorTypeModule.ZOMBIE_TOMBSTONE_SPAWNER_PROCESSOR;
     }
 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonEggRoomPiece.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonEggRoomPiece.java
@@ -41,7 +41,7 @@ public class SpiderDungeonEggRoomPiece extends SpiderDungeonPiece {
                                Y_MINRADIUS = 2, Y_MAXRADIUS = 3,
                                Z_MINRADIUS = 2, Z_MAXRADIUS = 3;
 
-    private static final BlockStateRandomizer WOOL_SELECTOR = BlockStateRandomizer.from(Blocks.WHITE_WOOL.defaultBlockState());
+    private static final BlockStateRandomizer WOOL_SELECTOR = BlockStateRandomizer.from(Blocks.WOOL.white().defaultBlockState());
     private static final BlockStateRandomizer COBWEB_SELECTOR = BlockStateRandomizer.from(Blocks.COBWEB.defaultBlockState());
 
     public SpiderDungeonEggRoomPiece(BlockPos startPos, int pieceChainLength) {
@@ -197,12 +197,12 @@ public class SpiderDungeonEggRoomPiece extends SpiderDungeonPiece {
         this.placeSphereRandomized(world, box, chestPos, 2, decoRand, .5f, WOOL_SELECTOR, false);
 
         // Guarantee wool immediately around chest
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX() + 1, chestPos.getY(), chestPos.getZ(), box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX() - 1, chestPos.getY(), chestPos.getZ(), box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ() + 1, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ() - 1, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX(), chestPos.getY() - 1, chestPos.getZ(), box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), chestPos.getX(), chestPos.getY() + 1, chestPos.getZ(), box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), chestPos.getX() + 1, chestPos.getY(), chestPos.getZ(), box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), chestPos.getX() - 1, chestPos.getY(), chestPos.getZ(), box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ() + 1, box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ() - 1, box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), chestPos.getX(), chestPos.getY() - 1, chestPos.getZ(), box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), chestPos.getX(), chestPos.getY() + 1, chestPos.getZ(), box);
 
         // Surround egg with more cobweb
         this.placeSphereRandomized(world, box, chestPos.getX(), chestPos.getY(), chestPos.getZ(), 2, decoRand, .4f, COBWEB_SELECTOR, true);
@@ -216,7 +216,7 @@ public class SpiderDungeonEggRoomPiece extends SpiderDungeonPiece {
                 this.placeBlock(world, Blocks.SPAWNER.defaultBlockState(), chestPos.getX(), chestPos.getY(), chestPos.getZ(), box);
                 BlockEntity spawnerBlockEntity = world.getBlockEntity(chestPos);
                 if (spawnerBlockEntity instanceof SpawnerBlockEntity) {
-                    ((SpawnerBlockEntity) spawnerBlockEntity).setEntityId(EntityType.SPIDER, randomSource);
+                    ((SpawnerBlockEntity) spawnerBlockEntity).setEntityId(net.minecraft.world.entity.EntityTypes.SPIDER, randomSource);
                 } else {
                     BetterDungeonsCommon.LOGGER.warn("Expected spider spawner entity at {}, but found none!", chestPos);
                 }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonNestPiece.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonNestPiece.java
@@ -42,7 +42,7 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
                                Z_MINRADIUS = 6, Z_MAXRADIUS = 10;
 
     private static final BlockStateRandomizer COBWEB_SELECTOR = BlockStateRandomizer.from(Blocks.COBWEB.defaultBlockState());
-    private static final BlockStateRandomizer WOOL_SELECTOR = BlockStateRandomizer.from(Blocks.WHITE_WOOL.defaultBlockState());
+    private static final BlockStateRandomizer WOOL_SELECTOR = BlockStateRandomizer.from(Blocks.WOOL.white().defaultBlockState());
 
     public SpiderDungeonNestPiece(BlockPos startPos, int pieceChainLength) {
         super(StructurePieceTypeModule.NEST, pieceChainLength, getInitialBoundingBox(startPos));
@@ -169,7 +169,7 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
                     float radialDist = radialXDist * radialXDist + radialYDist * radialYDist + radialZDist * radialZDist;
                     if (radialDist < 1.0) {
                         if (globalX == caveStartX && globalZ == caveStartZ && globalY > caveStartY) {
-                            this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), globalX, globalY, globalZ, box);
+                            this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), globalX, globalY, globalZ, box);
                         } else if (!carvingMask.get(mask)) {
                             if (!BLOCK_BLACKLIST.contains(this.getBlock(world, globalX, globalY, globalZ, box).getBlock())) {
                                 this.placeBlock(world, Blocks.CAVE_AIR.defaultBlockState(), globalX, globalY, globalZ, box);
@@ -185,7 +185,7 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
                         float radialDistShell = radialXDistShell * radialXDistShell + radialYDistShell * radialYDistShell + radialZDistShell * radialZDistShell;
                         if (radialDistShell < 1.0) {
                             if (globalX == caveStartX && globalZ == caveStartZ && globalY > caveStartY) { // Guarantee wool up to ceiling
-                                this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), globalX, globalY, globalZ, box);
+                                this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), globalX, globalY, globalZ, box);
                             } else if (!carvingMask.get(mask)) { // Only place cobble shell on outer rim
                                 BlockState state = this.getBlock(world, globalX, globalY, globalZ, box);
 //                                if (!BLOCK_BLACKLIST.contains(state.getBlock())) { // Ignore blacklisted blocks
@@ -212,11 +212,11 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
         this.placeSphereRandomized(world, box, (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ, 2, decoRand, .5f, WOOL_SELECTOR, true);
 
         // Guarantee wool immediately around spawner
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX + 1, (int) caveStartY + 1, (int) caveStartZ, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX - 1, (int) caveStartY + 1, (int) caveStartZ, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ + 1, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ - 1, box);
-        this.placeBlock(world, Blocks.WHITE_WOOL.defaultBlockState(), (int) caveStartX, (int) caveStartY, (int) caveStartZ, box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), (int) caveStartX + 1, (int) caveStartY + 1, (int) caveStartZ, box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), (int) caveStartX - 1, (int) caveStartY + 1, (int) caveStartZ, box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ + 1, box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ - 1, box);
+        this.placeBlock(world, Blocks.WOOL.white().defaultBlockState(), (int) caveStartX, (int) caveStartY, (int) caveStartZ, box);
 
         // Surround cocoon with more cobweb
         this.placeSphereRandomized(world, box, (int) caveStartX, (int) caveStartY + 1, (int) caveStartZ, 3, decoRand, .5f, COBWEB_SELECTOR, true);
@@ -226,7 +226,7 @@ public class SpiderDungeonNestPiece extends SpiderDungeonPiece {
         if (box.isInside(startPos)) {
             BlockEntity spawnerTileEntity = world.getBlockEntity(startPos.relative(Direction.UP));
             if (spawnerTileEntity instanceof SpawnerBlockEntity) {
-                ((SpawnerBlockEntity) spawnerTileEntity).setEntityId(EntityType.CAVE_SPIDER, randomSource);
+                ((SpawnerBlockEntity) spawnerTileEntity).setEntityId(net.minecraft.world.entity.EntityTypes.CAVE_SPIDER, randomSource);
             } else {
                 BetterDungeonsCommon.LOGGER.warn("Expected cave spider spawner entity at {}, but found none!", startPos.relative(Direction.UP));
             }

--- a/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonPiece.java
+++ b/Common/src/main/java/com/yungnickyoung/minecraft/betterdungeons/world/structure/spider_dungeon/piece/SpiderDungeonPiece.java
@@ -18,7 +18,7 @@ import java.util.BitSet;
 import java.util.Set;
 
 public abstract class SpiderDungeonPiece extends StructurePiece {
-    protected static final Set<Block> BLOCK_BLACKLIST = Sets.newHashSet(Blocks.DIAMOND_BLOCK, Blocks.WHITE_WOOL, Blocks.SPAWNER, Blocks.CHEST, Blocks.ACACIA_LEAVES, Blocks.BIRCH_LEAVES, Blocks.OAK_LEAVES, Blocks.DARK_OAK_LEAVES, Blocks.JUNGLE_LEAVES, Blocks.SPRUCE_LEAVES, Blocks.SHORT_GRASS, Blocks.TALL_GRASS);
+    protected static final Set<Block> BLOCK_BLACKLIST = Sets.newHashSet(Blocks.DIAMOND_BLOCK, Blocks.WOOL.white(), Blocks.SPAWNER, Blocks.CHEST, Blocks.ACACIA_LEAVES, Blocks.BIRCH_LEAVES, Blocks.OAK_LEAVES, Blocks.DARK_OAK_LEAVES, Blocks.JUNGLE_LEAVES, Blocks.SPRUCE_LEAVES, Blocks.SHORT_GRASS, Blocks.TALL_GRASS);
 
     protected SpiderDungeonPiece(StructurePieceType structurePieceTypeIn, int chainLength, BoundingBox box) {
         super(structurePieceTypeIn, chainLength, box);

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,16 @@ mod_description=A complete redesign of Minecraft's dungeons!
 mod_credits=Thanks so much to all my patrons!
 license=LGPLv3
 maven_group=com.yungnickyoung.minecraft.betterdungeons
-mc_version=26.1.2
-mc_version_range=[26.1,)
-mc_version_range_fabric=>=26.1
+mc_version=26.2
+mc_version_range=[26.2,)
+mc_version_range_fabric=>=26.2
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-mc_version_neo_form=26.1.2-1
+mc_version_neo_form=26.2-2
 
 # CurseForge/Modrinth Publishing
 cursegradle_version=1.1.24
-compatible_versions=26.1.1,26.1.2
+compatible_versions=26.2
 curseforge_project_id_fabric=525586
 curseforge_project_id_neoforge=510089
 modrinth_project_id=o1C1Dkj5
@@ -30,14 +30,14 @@ debug_publish=true
 yungsapi_version=6.1.0
 
 # Fabric
-fabric_version=0.150.0
-fabric_loader_version=0.18.6
-clothconfig_version_fabric=26.1.154
-modmenu_version_fabric=18.0.0-beta.1
+fabric_version=0.154.2
+fabric_loader_version=0.19.3
+clothconfig_version_fabric=26.2.155
+modmenu_version_fabric=20.0.1
 
 # NeoForge
-neoforge_version=26.1.2.75
-neoforge_version_range=[26.1.2.75,)
+neoforge_version=26.2.0.41-beta
+neoforge_version_range=[26.2.0.41-beta,)
 neoforge_loader_version_range=[4,)
 
 # Credentials for publishing. Gets overwritten with global gradle.properties.


### PR DESCRIPTION
## Summary

- update the Minecraft, Fabric, Fabric API, Cloth Config, Mod Menu, NeoForm, and NeoForge targets for Minecraft 26.2
- migrate the Minecraft 26.2 APIs and data formats used by this project
- keep the Common, Fabric, and NeoForge modules aligned with the YUNG's API 26.2 port

Depends on YUNG-GANG/YUNGs-API#109.

## Validation

- `gradlew build --no-daemon --console=plain` passes for Common, Fabric, and NeoForge on Java 25
- Fabric client and server startup were validated in a Minecraft 26.2 PrismLauncher instance
- the build was tested against the Common, Fabric, and NeoForge artifacts from the YUNG's API 26.2 port

The existing LGPL-3.0 license is preserved.
